### PR TITLE
Fix merlin error codes

### DIFF
--- a/e2e/api/api_test.go
+++ b/e2e/api/api_test.go
@@ -25,16 +25,9 @@ func TestE2EAPI(t *testing.T) {
 	RunSpecs(t, "E2E API Suite")
 }
 
-var _ = Describe("server API validation", func() {
+var _ = Describe("API", func() {
 	BeforeSuite(func() {
 		SetupE2E()
-		StartEtcd()
-		StartMerlin()
-	})
-
-	AfterSuite(func() {
-		StopEtcd()
-		StopMerlin()
 	})
 
 	var (
@@ -45,6 +38,9 @@ var _ = Describe("server API validation", func() {
 	)
 
 	BeforeEach(func() {
+		StartEtcd()
+		StartMerlin()
+
 		dest := fmt.Sprintf("localhost:%s", MerlinPort())
 		fmt.Fprintf(os.Stderr, "dialing %s\n", dest)
 		c, err := grpc.Dial(dest, grpc.WithInsecure())
@@ -60,208 +56,334 @@ var _ = Describe("server API validation", func() {
 	AfterEach(func() {
 		cancelCall()
 		conn.Close()
+		StopEtcd()
+		StopMerlin()
 	})
 
-	DescribeTable("CreateService", func(service *types.VirtualService) {
-		_, err := client.CreateService(ctx, service)
-		status, ok := status.FromError(err)
+	Describe("CreateService", func() {
 
-		Expect(ok).To(BeTrue(), "got grpc status error")
-		if ok {
-			Expect(status.Code()).To(Equal(codes.InvalidArgument),
-				"expected InvalidArgument, but got %v", err)
-		}
-	},
-		Entry("empty service", &types.VirtualService{}),
-		Entry("missing id", &types.VirtualService{
-			Key: &types.VirtualService_Key{
-				Ip:       "127.0.0.1",
-				Port:     8080,
-				Protocol: types.Protocol_TCP,
-			},
-			Config: &types.VirtualService_Config{
-				Scheduler: "sh",
-			},
-		}),
-		Entry("missing IP", &types.VirtualService{
-			Id: "service1",
-			Key: &types.VirtualService_Key{
-				Port:     8080,
-				Protocol: types.Protocol_TCP,
-			},
-			Config: &types.VirtualService_Config{
-				Scheduler: "sh",
-			},
-		}),
-		Entry("invalid IP", &types.VirtualService{
-			Id: "service1",
-			Key: &types.VirtualService_Key{
-				Ip:       "999.999.999.999",
-				Port:     8080,
-				Protocol: types.Protocol_TCP,
-			},
-			Config: &types.VirtualService_Config{
-				Scheduler: "sh",
-			},
-		}),
-		Entry("invalid port", &types.VirtualService{
-			Id: "service1",
-			Key: &types.VirtualService_Key{
-				Ip:       "127.0.0.1",
-				Port:     99999,
-				Protocol: types.Protocol_TCP,
-			},
-			Config: &types.VirtualService_Config{
-				Scheduler: "sh",
-			},
-		}),
-		Entry("zero port", &types.VirtualService{
-			Id: "service1",
-			Key: &types.VirtualService_Key{
-				Ip:       "127.0.0.1",
-				Port:     0,
-				Protocol: types.Protocol_TCP,
-			},
-			Config: &types.VirtualService_Config{
-				Scheduler: "sh",
-			},
-		}),
-		Entry("missing protocol", &types.VirtualService{
-			Id: "service1",
-			Key: &types.VirtualService_Key{
-				Ip:   "127.0.0.1",
-				Port: 8080,
-			},
-			Config: &types.VirtualService_Config{
-				Scheduler: "sh",
-			},
-		}),
-		Entry("invalid protocol", &types.VirtualService{
-			Id: "service1",
-			Key: &types.VirtualService_Key{
-				Ip:       "127.0.0.1",
-				Port:     8080,
-				Protocol: 999,
-			},
-			Config: &types.VirtualService_Config{
-				Scheduler: "sh",
-			},
-		}),
-		Entry("config required", &types.VirtualService{
-			Id: "service1",
-			Key: &types.VirtualService_Key{
-				Ip:       "127.0.0.1",
-				Port:     8080,
-				Protocol: types.Protocol_TCP,
-			},
-		}),
-		Entry("scheduler required", &types.VirtualService{
-			Id: "service1",
-			Key: &types.VirtualService_Key{
-				Ip:       "127.0.0.1",
-				Port:     8080,
-				Protocol: types.Protocol_TCP,
-			},
-			Config: &types.VirtualService_Config{},
-		}),
-	)
+		DescribeTable("field validation", func(service *types.VirtualService) {
+			_, err := client.CreateService(ctx, service)
+			status, ok := status.FromError(err)
 
-	DescribeTable("CreateServer", func(server *types.RealServer) {
-		_, err := client.CreateServer(ctx, server)
-		status, ok := status.FromError(err)
+			Expect(ok).To(BeTrue(), "got grpc status error")
+			if ok {
+				Expect(status.Code()).To(Equal(codes.InvalidArgument),
+					"expected InvalidArgument, but got %v", err)
+			}
+		},
+			Entry("empty service", &types.VirtualService{}),
+			Entry("missing id", &types.VirtualService{
+				Key: &types.VirtualService_Key{
+					Ip:       "127.0.0.1",
+					Port:     8080,
+					Protocol: types.Protocol_TCP,
+				},
+				Config: &types.VirtualService_Config{
+					Scheduler: "sh",
+				},
+			}),
+			Entry("missing IP", &types.VirtualService{
+				Id: "service1",
+				Key: &types.VirtualService_Key{
+					Port:     8080,
+					Protocol: types.Protocol_TCP,
+				},
+				Config: &types.VirtualService_Config{
+					Scheduler: "sh",
+				},
+			}),
+			Entry("invalid IP", &types.VirtualService{
+				Id: "service1",
+				Key: &types.VirtualService_Key{
+					Ip:       "999.999.999.999",
+					Port:     8080,
+					Protocol: types.Protocol_TCP,
+				},
+				Config: &types.VirtualService_Config{
+					Scheduler: "sh",
+				},
+			}),
+			Entry("invalid port", &types.VirtualService{
+				Id: "service1",
+				Key: &types.VirtualService_Key{
+					Ip:       "127.0.0.1",
+					Port:     99999,
+					Protocol: types.Protocol_TCP,
+				},
+				Config: &types.VirtualService_Config{
+					Scheduler: "sh",
+				},
+			}),
+			Entry("zero port", &types.VirtualService{
+				Id: "service1",
+				Key: &types.VirtualService_Key{
+					Ip:       "127.0.0.1",
+					Port:     0,
+					Protocol: types.Protocol_TCP,
+				},
+				Config: &types.VirtualService_Config{
+					Scheduler: "sh",
+				},
+			}),
+			Entry("missing protocol", &types.VirtualService{
+				Id: "service1",
+				Key: &types.VirtualService_Key{
+					Ip:   "127.0.0.1",
+					Port: 8080,
+				},
+				Config: &types.VirtualService_Config{
+					Scheduler: "sh",
+				},
+			}),
+			Entry("invalid protocol", &types.VirtualService{
+				Id: "service1",
+				Key: &types.VirtualService_Key{
+					Ip:       "127.0.0.1",
+					Port:     8080,
+					Protocol: 999,
+				},
+				Config: &types.VirtualService_Config{
+					Scheduler: "sh",
+				},
+			}),
+			Entry("config required", &types.VirtualService{
+				Id: "service1",
+				Key: &types.VirtualService_Key{
+					Ip:       "127.0.0.1",
+					Port:     8080,
+					Protocol: types.Protocol_TCP,
+				},
+			}),
+			Entry("scheduler required", &types.VirtualService{
+				Id: "service1",
+				Key: &types.VirtualService_Key{
+					Ip:       "127.0.0.1",
+					Port:     8080,
+					Protocol: types.Protocol_TCP,
+				},
+				Config: &types.VirtualService_Config{},
+			}),
+		)
 
-		Expect(ok).To(BeTrue(), "got grpc status error")
-		if ok {
-			Expect(status.Code()).To(Equal(codes.InvalidArgument),
-				"expected InvalidArgument, but got %v", err)
-		}
-	},
-		Entry("empty server", &types.RealServer{}),
-		Entry("missing serviceID", &types.RealServer{
-			Key: &types.RealServer_Key{
-				Ip:   "172.16.1.1",
-				Port: 9090,
-			},
-			Config: &types.RealServer_Config{
-				Weight:  &wrappers.UInt32Value{Value: 2},
-				Forward: types.ForwardMethod_ROUTE,
-			},
-		}),
-		Entry("missing key", &types.RealServer{
-			ServiceID: "service1",
-			Config: &types.RealServer_Config{
-				Weight:  &wrappers.UInt32Value{Value: 2},
-				Forward: types.ForwardMethod_ROUTE,
-			},
-		}),
-		Entry("missing ip", &types.RealServer{
-			ServiceID: "service1",
-			Key: &types.RealServer_Key{
-				Port: 9090,
-			},
-			Config: &types.RealServer_Config{
-				Weight:  &wrappers.UInt32Value{Value: 2},
-				Forward: types.ForwardMethod_ROUTE,
-			},
-		}),
-		Entry("invalid ip", &types.RealServer{
-			ServiceID: "service1",
-			Key: &types.RealServer_Key{
-				Ip:   "999.999.999.999",
-				Port: 9090,
-			},
-			Config: &types.RealServer_Config{
-				Weight:  &wrappers.UInt32Value{Value: 2},
-				Forward: types.ForwardMethod_ROUTE,
-			},
-		}),
-		Entry("invalid port", &types.RealServer{
-			ServiceID: "service1",
-			Key: &types.RealServer_Key{
-				Ip:   "127.0.0.1",
-				Port: 99999,
-			},
-			Config: &types.RealServer_Config{
-				Weight:  &wrappers.UInt32Value{Value: 2},
-				Forward: types.ForwardMethod_ROUTE,
-			},
-		}),
-		Entry("missing port", &types.RealServer{
-			ServiceID: "service1",
-			Key: &types.RealServer_Key{
-				Ip: "172.16.1.1",
-			},
-			Config: &types.RealServer_Config{
-				Weight:  &wrappers.UInt32Value{Value: 2},
-				Forward: types.ForwardMethod_ROUTE,
-			},
-		}),
-		Entry("missing config", &types.RealServer{
-			ServiceID: "service1",
-			Key: &types.RealServer_Key{
-				Ip:   "172.16.1.1",
-				Port: 9090,
-			},
-		}),
-		Entry("missing forward method", &types.RealServer{
-			ServiceID: "service1",
-			Key: &types.RealServer_Key{
-				Ip:   "172.16.1.1",
-				Port: 9090,
-			},
-			Config: &types.RealServer_Config{
-				Weight: &wrappers.UInt32Value{Value: 2},
-			},
-		}),
-		Entry("missing weight", &types.RealServer{
-			ServiceID: "service1",
-			Key: &types.RealServer_Key{
-				Ip:   "172.16.1.1",
-				Port: 9090,
-			},
-			Config: &types.RealServer_Config{
-				Forward: types.ForwardMethod_ROUTE,
-			},
-		}),
-	)
+		It("should return codes.AlreadyExists if already exists", func() {
+			svc1 := &types.VirtualService{
+				Id: "service1",
+				Key: &types.VirtualService_Key{
+					Ip:       "127.0.0.1",
+					Port:     8080,
+					Protocol: types.Protocol_TCP,
+				},
+				Config: &types.VirtualService_Config{
+					Scheduler: "sh",
+				},
+			}
+			svc2 := &types.VirtualService{
+				Id: svc1.Id,
+				Key: &types.VirtualService_Key{
+					Ip:       "127.0.0.2",
+					Port:     9090,
+					Protocol: types.Protocol_TCP,
+				},
+				Config: &types.VirtualService_Config{
+					Scheduler: "wrr",
+				},
+			}
+
+			_, err := client.CreateService(ctx, svc1)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = client.CreateService(ctx, svc2)
+			status, ok := status.FromError(err)
+
+			Expect(ok).To(BeTrue(), "got grpc status error")
+			if ok {
+				Expect(status.Code()).To(Equal(codes.AlreadyExists),
+					"expected AlreadyExists, but got %v", err)
+			}
+		})
+	})
+
+	Describe("UpdateService", func() {
+
+		It("should return codes.NotFound if no existing service", func() {
+			svc := &types.VirtualService{
+				Id: "service1",
+				Key: &types.VirtualService_Key{
+					Ip:       "127.0.0.1",
+					Port:     8080,
+					Protocol: types.Protocol_TCP,
+				},
+				Config: &types.VirtualService_Config{
+					Scheduler: "sh",
+				},
+			}
+			_, err := client.UpdateService(ctx, svc)
+			status, ok := status.FromError(err)
+
+			Expect(ok).To(BeTrue(), "got grpc status error")
+			if ok {
+				Expect(status.Code()).To(Equal(codes.NotFound),
+					"expected NotFound, but got %v", err)
+			}
+		})
+	})
+
+	Describe("CreateServer", func() {
+
+		DescribeTable("field validation", func(server *types.RealServer) {
+			_, err := client.CreateServer(ctx, server)
+			status, ok := status.FromError(err)
+
+			Expect(ok).To(BeTrue(), "got grpc status error")
+			if ok {
+				Expect(status.Code()).To(Equal(codes.InvalidArgument),
+					"expected InvalidArgument, but got %v", err)
+			}
+		},
+			Entry("empty server", &types.RealServer{}),
+			Entry("missing serviceID", &types.RealServer{
+				Key: &types.RealServer_Key{
+					Ip:   "172.16.1.1",
+					Port: 9090,
+				},
+				Config: &types.RealServer_Config{
+					Weight:  &wrappers.UInt32Value{Value: 2},
+					Forward: types.ForwardMethod_ROUTE,
+				},
+			}),
+			Entry("missing key", &types.RealServer{
+				ServiceID: "service1",
+				Config: &types.RealServer_Config{
+					Weight:  &wrappers.UInt32Value{Value: 2},
+					Forward: types.ForwardMethod_ROUTE,
+				},
+			}),
+			Entry("missing ip", &types.RealServer{
+				ServiceID: "service1",
+				Key: &types.RealServer_Key{
+					Port: 9090,
+				},
+				Config: &types.RealServer_Config{
+					Weight:  &wrappers.UInt32Value{Value: 2},
+					Forward: types.ForwardMethod_ROUTE,
+				},
+			}),
+			Entry("invalid ip", &types.RealServer{
+				ServiceID: "service1",
+				Key: &types.RealServer_Key{
+					Ip:   "999.999.999.999",
+					Port: 9090,
+				},
+				Config: &types.RealServer_Config{
+					Weight:  &wrappers.UInt32Value{Value: 2},
+					Forward: types.ForwardMethod_ROUTE,
+				},
+			}),
+			Entry("invalid port", &types.RealServer{
+				ServiceID: "service1",
+				Key: &types.RealServer_Key{
+					Ip:   "127.0.0.1",
+					Port: 99999,
+				},
+				Config: &types.RealServer_Config{
+					Weight:  &wrappers.UInt32Value{Value: 2},
+					Forward: types.ForwardMethod_ROUTE,
+				},
+			}),
+			Entry("missing port", &types.RealServer{
+				ServiceID: "service1",
+				Key: &types.RealServer_Key{
+					Ip: "172.16.1.1",
+				},
+				Config: &types.RealServer_Config{
+					Weight:  &wrappers.UInt32Value{Value: 2},
+					Forward: types.ForwardMethod_ROUTE,
+				},
+			}),
+			Entry("missing config", &types.RealServer{
+				ServiceID: "service1",
+				Key: &types.RealServer_Key{
+					Ip:   "172.16.1.1",
+					Port: 9090,
+				},
+			}),
+			Entry("missing forward method", &types.RealServer{
+				ServiceID: "service1",
+				Key: &types.RealServer_Key{
+					Ip:   "172.16.1.1",
+					Port: 9090,
+				},
+				Config: &types.RealServer_Config{
+					Weight: &wrappers.UInt32Value{Value: 2},
+				},
+			}),
+			Entry("missing weight", &types.RealServer{
+				ServiceID: "service1",
+				Key: &types.RealServer_Key{
+					Ip:   "172.16.1.1",
+					Port: 9090,
+				},
+				Config: &types.RealServer_Config{
+					Forward: types.ForwardMethod_ROUTE,
+				},
+			}),
+		)
+
+		It("should return codes.AlreadyExists if already exists", func() {
+			server1 := &types.RealServer{
+				ServiceID: "service1",
+				Key: &types.RealServer_Key{
+					Ip:   "172.16.1.1",
+					Port: 9090,
+				},
+				Config: &types.RealServer_Config{
+					Weight:  &wrappers.UInt32Value{Value: 2},
+					Forward: types.ForwardMethod_ROUTE,
+				},
+			}
+			server2 := &types.RealServer{
+				ServiceID: server1.ServiceID,
+				Key:       server1.Key,
+				Config: &types.RealServer_Config{
+					Weight:  &wrappers.UInt32Value{Value: 1},
+					Forward: types.ForwardMethod_TUNNEL,
+				},
+			}
+			_, err := client.CreateServer(ctx, server1)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = client.CreateServer(ctx, server2)
+			status, ok := status.FromError(err)
+
+			Expect(ok).To(BeTrue(), "got grpc status error")
+			if ok {
+				Expect(status.Code()).To(Equal(codes.AlreadyExists),
+					"expected AlreadyExists, but got %v", err)
+			}
+		})
+	})
+
+	Describe("UpdateServer", func() {
+
+		It("should return codes.NotFound if doesn't exist", func() {
+			server := &types.RealServer{
+				ServiceID: "service1",
+				Key: &types.RealServer_Key{
+					Ip:   "172.16.1.1",
+					Port: 9090,
+				},
+				Config: &types.RealServer_Config{
+					Weight:  &wrappers.UInt32Value{Value: 2},
+					Forward: types.ForwardMethod_ROUTE,
+				},
+			}
+			_, err := client.UpdateServer(ctx, server)
+			status, ok := status.FromError(err)
+
+			Expect(ok).To(BeTrue(), "got grpc status error")
+			if ok {
+				Expect(status.Code()).To(Equal(codes.NotFound),
+					"expected NotFound, but got %v", err)
+			}
+		})
+	})
 })

--- a/server/server.go
+++ b/server/server.go
@@ -171,9 +171,17 @@ func (s *server) CreateServer(ctx context.Context, server *types.RealServer) (*e
 		return emptyResponse, err
 	}
 
+	svc, err := s.store.GetService(ctx, server.ServiceID)
+	if err != nil {
+		return emptyResponse, fmt.Errorf("failed to check service %s exists: %v", server.ServiceID, err)
+	}
+	if svc == nil {
+		return emptyResponse, status.Errorf(codes.NotFound, "service does not exist, can't create server %v", server)
+	}
+
 	prev, err := s.store.GetServer(ctx, server.ServiceID, server.Key)
 	if err != nil {
-		return emptyResponse, fmt.Errorf("failed to check service exists: %v", err)
+		return emptyResponse, fmt.Errorf("failed to check server %v exists: %v", server, err)
 	}
 	if prev != nil {
 		return emptyResponse, status.Errorf(codes.AlreadyExists, "server %v already exists", server)

--- a/server/server.go
+++ b/server/server.go
@@ -81,7 +81,7 @@ func (s *server) CreateService(ctx context.Context, service *types.VirtualServic
 		return emptyResponse, fmt.Errorf("failed to check service exists: %v", err)
 	}
 	if prev != nil {
-		return emptyResponse, status.Errorf(codes.InvalidArgument, "service %s already exists", service.Id)
+		return emptyResponse, status.Errorf(codes.AlreadyExists, "service %s already exists", service.Id)
 	}
 
 	if err := s.store.PutService(ctx, service); err != nil {
@@ -100,7 +100,7 @@ func (s *server) UpdateService(ctx context.Context, update *types.VirtualService
 		return emptyResponse, fmt.Errorf("failed to check server exists: %v", err)
 	}
 	if prev == nil {
-		return emptyResponse, status.Errorf(codes.InvalidArgument, "service %s doesn't exist", update.Id)
+		return emptyResponse, status.Errorf(codes.NotFound, "service %s doesn't exist", update.Id)
 	}
 
 	next := proto.Clone(prev).(*types.VirtualService)
@@ -176,7 +176,7 @@ func (s *server) CreateServer(ctx context.Context, server *types.RealServer) (*e
 		return emptyResponse, fmt.Errorf("failed to check service exists: %v", err)
 	}
 	if prev != nil {
-		return emptyResponse, status.Errorf(codes.InvalidArgument, "server %v already exists", server)
+		return emptyResponse, status.Errorf(codes.AlreadyExists, "server %v already exists", server)
 	}
 
 	if err := s.store.PutServer(ctx, server); err != nil {
@@ -195,7 +195,7 @@ func (s *server) UpdateServer(ctx context.Context, update *types.RealServer) (*e
 		return emptyResponse, fmt.Errorf("failed to check server exists: %v", err)
 	}
 	if prev == nil {
-		return emptyResponse, status.Errorf(codes.InvalidArgument, "server %s/%s doesn't exist",
+		return emptyResponse, status.Errorf(codes.NotFound, "server %s/%s doesn't exist",
 			update.ServiceID, update.Key)
 	}
 


### PR DESCRIPTION
To distinguish AlreadyExists vs NotFound vs InvalidArgument.

That way clients can decide how to handle e.g. if a service or server
already exists when creating.