### PR TITLE
watch etcd for changes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,6 +8,12 @@
   revision = "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9"
 
 [[projects]]
+  name = "github.com/cenkalti/backoff"
+  packages = ["."]
+  revision = "61153c768f31ee5f130071d08fc82b85208528de"
+  version = "v1.1.0"
+
+[[projects]]
   name = "github.com/coreos/etcd"
   packages = [
     "client",
@@ -322,6 +328,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1ae00c6bb7788834f9e2669c4b5fa98b780469d291ce94fcb2881148422f289d"
+  inputs-digest = "6f8dee594cbfacb5013550e97c034ab9c12ad02a664dcb543656ecc2e3f7e2da"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -56,7 +56,7 @@ func New(period time.Duration, store Store, ipvs ipvs.IPVS) Reconciler {
 }
 
 func (r *reconciler) Start() error {
-	log.Infof("Starting reconciler")
+	log.Debug("Starting reconciler")
 	go func() {
 		for {
 			t := time.NewTimer(r.period)
@@ -66,7 +66,7 @@ func (r *reconciler) Start() error {
 			case <-r.syncCh:
 				r.reconcile()
 			case <-r.stopCh:
-				log.Infof("Stopped reconciler")
+				log.Debug("Stopped reconciler")
 				return
 			}
 		}

--- a/reconciler/stub.go
+++ b/reconciler/stub.go
@@ -1,5 +1,9 @@
 package reconciler
 
+import (
+	log "github.com/sirupsen/logrus"
+)
+
 type stub struct{}
 
 // NewStub returns a reconciler which doesn't do anything.
@@ -8,13 +12,14 @@ func NewStub() Reconciler {
 }
 
 func (s *stub) Start() error {
+	log.Debug("stub-reconciler: Start()")
 	return nil
 }
 
 func (s *stub) Stop() {
-	// do nothing
+	log.Debug("stub-reconciler: Stop()")
 }
 
 func (s *stub) Sync() {
-	// do nothing
+	log.Debug("stub-reconciler: Sync()")
 }

--- a/server/server.go
+++ b/server/server.go
@@ -15,7 +15,6 @@ import (
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	log "github.com/sirupsen/logrus"
-	"github.com/sky-uk/merlin/reconciler"
 	"github.com/sky-uk/merlin/store"
 	"github.com/sky-uk/merlin/types"
 	"google.golang.org/grpc/codes"
@@ -23,15 +22,13 @@ import (
 )
 
 type server struct {
-	store      store.Store
-	reconciler reconciler.Reconciler
+	store store.Store
 }
 
 // New merlin server implementation.
-func New(store store.Store, reconciler reconciler.Reconciler) types.MerlinServer {
+func New(store store.Store) types.MerlinServer {
 	return &server{
-		store:      store,
-		reconciler: reconciler,
+		store: store,
 	}
 }
 
@@ -124,9 +121,7 @@ func (s *server) CreateService(ctx context.Context, service *types.VirtualServic
 		return emptyResponse, fmt.Errorf("failed to create service: %v", err)
 	}
 
-	s.reconciler.Sync()
-
-	log.Infof("Created %v", service)
+	log.Infof("Created virtual service: %v", service)
 	return emptyResponse, nil
 }
 
@@ -164,8 +159,6 @@ func (s *server) UpdateService(ctx context.Context, update *types.VirtualService
 		return emptyResponse, fmt.Errorf("failed to update service: %v", err)
 	}
 
-	s.reconciler.Sync()
-
 	log.Infof("Updated %v", next)
 	return emptyResponse, nil
 }
@@ -175,7 +168,6 @@ func (s *server) DeleteService(ctx context.Context, wrappedID *wrappers.StringVa
 	if err := s.store.DeleteService(ctx, id); err != nil {
 		return emptyResponse, fmt.Errorf("failed to delete service %s: %v", id, err)
 	}
-	s.reconciler.Sync()
 	log.Infof("Deleted %s", id)
 	return emptyResponse, nil
 }
@@ -236,9 +228,7 @@ func (s *server) CreateServer(ctx context.Context, server *types.RealServer) (*e
 		return emptyResponse, fmt.Errorf("failed to create server: %v", err)
 	}
 
-	s.reconciler.Sync()
-
-	log.Infof("Created %v", server)
+	log.Infof("Created real server: %v", server)
 	return emptyResponse, nil
 }
 
@@ -268,8 +258,6 @@ func (s *server) UpdateServer(ctx context.Context, update *types.RealServer) (*e
 		return emptyResponse, fmt.Errorf("failed to update server: %v", err)
 	}
 
-	s.reconciler.Sync()
-
 	log.Infof("Updated %v", next)
 	return emptyResponse, nil
 }
@@ -278,7 +266,6 @@ func (s *server) DeleteServer(ctx context.Context, server *types.RealServer) (*e
 	if err := s.store.DeleteServer(ctx, server.ServiceID, server.Key); err != nil {
 		return emptyResponse, fmt.Errorf("failed to delete server %s: %v", server, err)
 	}
-	s.reconciler.Sync()
 	log.Infof("Deleted %s/%s", server.ServiceID, server.Key)
 	return emptyResponse, nil
 }


### PR DESCRIPTION
Trigger reconciler sync whenever the etcd store changes. This allows for much quicker update of IPVS state across an IPVS cluster.