### PR TITLE
Swap to github.com/docker/libnetwork for ipvs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.2
+
+* Swap to github.com/docker/libnetwork for IPVS, to improve stability.
+
 # 0.1.1
 
 * Fix panics when updating with nil fields.

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -38,6 +38,12 @@
   version = "v1.1.0"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/docker/libnetwork"
+  packages = ["ipvs"]
+  revision = "5c1218c956c99f3365711974e300087810c31379"
+
+[[projects]]
   name = "github.com/gogo/protobuf"
   packages = ["proto"]
   revision = "1adfc126b41513cc696b209667c8656ea7aac67c"
@@ -58,12 +64,6 @@
   version = "v1.0.0"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/hkwi/nlgo"
-  packages = ["."]
-  revision = "dbae43f4fc47bf868bca3cc3c1ea2954c2059842"
-
-[[projects]]
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
@@ -74,12 +74,6 @@
   packages = ["pbutil"]
   revision = "3247c84500bff8d9fb6d579d800f20b3e091582c"
   version = "v1.0.0"
-
-[[projects]]
-  branch = "master"
-  name = "github.com/mqliang/libipvs"
-  packages = ["."]
-  revision = "38f5f7e6361787f0007b825811aa732d83888197"
 
 [[projects]]
   branch = "master"
@@ -131,12 +125,6 @@
   ]
   revision = "003f63b7f4cff3fc95357005358af2de0f5fe152"
   version = "v1.3.0"
-
-[[projects]]
-  name = "github.com/pkg/errors"
-  packages = ["."]
-  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
-  version = "v0.8.0"
 
 [[projects]]
   name = "github.com/pmezard/go-difflib"
@@ -218,6 +206,20 @@
   packages = ["codec"]
   revision = "9831f2c3ac1068a78f50999a30db84270f647af6"
   version = "v1.1"
+
+[[projects]]
+  name = "github.com/vishvananda/netlink"
+  packages = [
+    ".",
+    "nl"
+  ]
+  revision = "b2de5d10e38ecce8607e6b438b6d174f389a004e"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/vishvananda/netns"
+  packages = ["."]
+  revision = "be1fbeda19366dea804f00efff2dd73a1642fdcc"
 
 [[projects]]
   branch = "master"
@@ -328,6 +330,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "6f8dee594cbfacb5013550e97c034ab9c12ad02a664dcb543656ecc2e3f7e2da"
+  inputs-digest = "41ebad0811a4c0bb6127dabb4c6f8416e0a238cb59bd014e2ba7bbabe801ecdf"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,6 +24,17 @@
 #   go-tests = true
 #   unused-packages = true
 
+# To constrain the version for docker/libnetwork.
+required = ["github.com/vishvananda/netlink"]
+
+# See https://github.com/docker/libnetwork/blob/master/vendor.conf.
+[[constraint]]
+  name = "github.com/vishvananda/netlink"
+  revision = "b2de5d10e38ecce8607e6b438b6d174f389a004e"
+
+[[constraint]]
+  name = "github.com/docker/libnetwork"
+  branch = "master"
 
 [[constraint]]
   name = "github.com/sirupsen/logrus"
@@ -32,10 +43,6 @@
 [[constraint]]
   name = "github.com/golang/protobuf"
   version = "1.0.0"
-
-[[constraint]]
-  branch = "master"
-  name = "github.com/mqliang/libipvs"
 
 [[constraint]]
   name = "github.com/stretchr/testify"

--- a/ipvs/conversions.go
+++ b/ipvs/conversions.go
@@ -78,7 +78,7 @@ func toFlagBits(flags []string) uint32 {
 		if b, exists := schedulerFlags[flag]; exists {
 			flagbits |= b
 		} else {
-			log.Warnf("unknown scheduler flag %q, ignoring", flag)
+			log.Warnf("Unknown scheduler flag %q, ignoring", flag)
 		}
 	}
 	return flagbits

--- a/ipvs/conversions.go
+++ b/ipvs/conversions.go
@@ -1,0 +1,96 @@
+package ipvs
+
+import (
+	"fmt"
+	"sort"
+	"syscall"
+
+	"github.com/docker/libnetwork/ipvs"
+	log "github.com/sirupsen/logrus"
+	"github.com/sky-uk/merlin/types"
+)
+
+// Flag values are found in ip_vs.h in ipvsadm.
+const (
+	ipVsSvcFPersistent      = 0x0001         /* persistent port */
+	ipVsSvcFHashed          = 0x0002         /* hashed entry */
+	ipVsSvcFOnePacket       = 0x0004         /* one-packet scheduling */
+	ipVsSvcFSched1          = 0x0008         /* scheduler flag 1 */
+	ipVsSvcFSched2          = 0x0010         /* scheduler flag 2 */
+	ipVsSvcFSched3          = 0x0020         /* scheduler flag 3 */
+	ipVsSvcFSchedShFallback = ipVsSvcFSched1 /* SH fallback */
+	ipVsSvcFSchedShPort     = ipVsSvcFSched2 /* SH use port */
+)
+
+var (
+	schedulerFlags = map[string]uint32{
+		"flag-1": ipVsSvcFSched1,
+		"flag-2": ipVsSvcFSched2,
+		"flag-3": ipVsSvcFSched3,
+	}
+	schedulerFlagsInverted map[uint32]string
+
+	forwardingMethods = map[types.ForwardMethod]uint32{
+		types.ForwardMethod_ROUTE:  ipvs.ConnectionFlagDirectRoute,
+		types.ForwardMethod_MASQ:   ipvs.ConnectionFlagMasq,
+		types.ForwardMethod_TUNNEL: ipvs.ConnectionFlagTunnel,
+	}
+	forwardingMethodsInverted map[uint32]types.ForwardMethod
+)
+
+func init() {
+	schedulerFlagsInverted = make(map[uint32]string)
+	for k, v := range schedulerFlags {
+		schedulerFlagsInverted[v] = k
+	}
+	forwardingMethodsInverted = make(map[uint32]types.ForwardMethod)
+	for k, v := range forwardingMethods {
+		forwardingMethodsInverted[v] = k
+	}
+}
+
+func toProtocolBits(protocol types.Protocol) (uint16, error) {
+	switch protocol {
+	case types.Protocol_TCP:
+		return syscall.IPPROTO_TCP, nil
+	case types.Protocol_UDP:
+		return syscall.IPPROTO_UDP, nil
+	default:
+		return 0, fmt.Errorf("unknown protocol %q", protocol)
+	}
+}
+
+func fromProtocolBits(protocol uint16) (types.Protocol, error) {
+	switch protocol {
+	case syscall.IPPROTO_TCP:
+		return types.Protocol_TCP, nil
+	case syscall.IPPROTO_UDP:
+		return types.Protocol_UDP, nil
+	default:
+		return 0, fmt.Errorf("unknown protocol %q", protocol)
+	}
+}
+
+// toFlagBits returns the uint32 bitset for a list of flags.
+func toFlagBits(flags []string) uint32 {
+	var flagbits uint32
+	for _, flag := range flags {
+		if b, exists := schedulerFlags[flag]; exists {
+			flagbits |= b
+		} else {
+			log.Warnf("unknown scheduler flag %q, ignoring", flag)
+		}
+	}
+	return flagbits
+}
+
+func fromFlagBits(flagbits uint32) []string {
+	var flags []string
+	for f, v := range schedulerFlagsInverted {
+		if flagbits&f != 0 {
+			flags = append(flags, v)
+		}
+	}
+	sort.Strings(flags)
+	return flags
+}

--- a/ipvs/shim.go
+++ b/ipvs/shim.go
@@ -8,43 +8,14 @@ import (
 
 	"net"
 
-	"sort"
-
+	"github.com/docker/libnetwork/ipvs"
 	"github.com/golang/protobuf/ptypes/wrappers"
-	"github.com/mqliang/libipvs"
-	log "github.com/sirupsen/logrus"
 	"github.com/sky-uk/merlin/types"
 )
 
-var (
-	schedulerFlags = map[string]uint32{
-		"flag-1": libipvs.IP_VS_SVC_F_SCHED1,
-		"flag-2": libipvs.IP_VS_SVC_F_SCHED2,
-		"flag-3": libipvs.IP_VS_SVC_F_SCHED3,
-	}
-	schedulerFlagsInverted map[uint32]string
-
-	forwardingMethods = map[types.ForwardMethod]libipvs.FwdMethod{
-		types.ForwardMethod_ROUTE:  libipvs.IP_VS_CONN_F_DROUTE,
-		types.ForwardMethod_MASQ:   libipvs.IP_VS_CONN_F_MASQ,
-		types.ForwardMethod_TUNNEL: libipvs.IP_VS_CONN_F_TUNNEL,
-	}
-	forwardingMethodsInverted map[libipvs.FwdMethod]types.ForwardMethod
-)
-
-func init() {
-	schedulerFlagsInverted = make(map[uint32]string)
-	for k, v := range schedulerFlags {
-		schedulerFlagsInverted[v] = k
-	}
-	forwardingMethodsInverted = make(map[libipvs.FwdMethod]types.ForwardMethod)
-	for k, v := range forwardingMethods {
-		forwardingMethodsInverted[v] = k
-	}
-}
-
 // IPVS shim.
 type IPVS interface {
+	Close()
 	AddService(svc *types.VirtualService) error
 	UpdateService(svc *types.VirtualService) error
 	DeleteService(key *types.VirtualService_Key) error
@@ -55,77 +26,59 @@ type IPVS interface {
 	ListServers(key *types.VirtualService_Key) ([]*types.RealServer, error)
 }
 
+// ipvsHandle for libnetwork/ipvs.
+type ipvsHandle interface {
+	Close()
+	GetServices() ([]*ipvs.Service, error)
+	NewService(*ipvs.Service) error
+	UpdateService(*ipvs.Service) error
+	DelService(*ipvs.Service) error
+	GetDestinations(*ipvs.Service) ([]*ipvs.Destination, error)
+	NewDestination(*ipvs.Service, *ipvs.Destination) error
+	UpdateDestination(*ipvs.Service, *ipvs.Destination) error
+	DelDestination(*ipvs.Service, *ipvs.Destination) error
+}
+
 type shim struct {
-	handle libipvs.IPVSHandle
+	handle ipvsHandle
 }
 
-// New IPVS shim.
-func New(handle libipvs.IPVSHandle) IPVS {
+// New IPVS shim. This creates an underlying netlink socket. Call Close() to release the associated resources.
+func New() (IPVS, error) {
+	h, err := ipvs.New("/")
+	if err != nil {
+		return nil, fmt.Errorf("unable to init ipvs: %v", err)
+	}
 	return &shim{
-		handle: handle,
-	}
+		handle: h,
+	}, nil
 }
 
-func toIPVSProtocol(protocol types.Protocol) (libipvs.Protocol, error) {
-	switch protocol {
-	case types.Protocol_TCP:
-		return libipvs.Protocol(syscall.IPPROTO_TCP), nil
-	case types.Protocol_UDP:
-		return libipvs.Protocol(syscall.IPPROTO_UDP), nil
-	default:
-		return 0, fmt.Errorf("unknown protocol %q", protocol)
-	}
+func (s *shim) Close() {
+	s.handle.Close()
 }
 
-func fromIPVSProtocol(protocol libipvs.Protocol) (types.Protocol, error) {
-	switch protocol {
-	case syscall.IPPROTO_TCP:
-		return types.Protocol_TCP, nil
-	case syscall.IPPROTO_UDP:
-		return types.Protocol_UDP, nil
-	default:
-		return 0, fmt.Errorf("unknown protocol %q", protocol)
-	}
-}
-
-func initIPVSService(key *types.VirtualService_Key) (*libipvs.Service, error) {
-	protNum, err := toIPVSProtocol(key.Protocol)
+func createHandleService(key *types.VirtualService_Key) (*ipvs.Service, error) {
+	protNum, err := toProtocolBits(key.Protocol)
 	if err != nil {
 		return nil, err
 	}
-	svc := &libipvs.Service{
+	svc := &ipvs.Service{
 		Address:       net.ParseIP(key.Ip),
-		Protocol:      libipvs.Protocol(protNum),
+		Protocol:      protNum,
 		Port:          uint16(key.Port),
 		AddressFamily: syscall.AF_INET,
 	}
 	return svc, nil
 }
 
-func createFlagbits(flags []string) (libipvs.Flags, error) {
-	var flagbits uint32
-	for _, flag := range flags {
-		if b, exists := schedulerFlags[flag]; exists {
-			flagbits |= b
-		} else {
-			log.Warnf("unknown scheduler flag %q, ignoring", flag)
-		}
-	}
-	r := libipvs.Flags{
-		Flags: flagbits,
-		// set all bits to 1
-		Mask: ^uint32(0),
-	}
-	return r, nil
-}
-
 func (s *shim) AddService(svc *types.VirtualService) error {
-	ipvsSvc, err := initIPVSService(svc.Key)
+	ipvsSvc, err := createHandleService(svc.Key)
 	if err != nil {
 		return err
 	}
 	ipvsSvc.SchedName = svc.Config.Scheduler
-	ipvsSvc.Flags, err = createFlagbits(svc.Config.Flags)
+	ipvsSvc.Flags = toFlagBits(svc.Config.Flags)
 	if err != nil {
 		return err
 	}
@@ -133,12 +86,12 @@ func (s *shim) AddService(svc *types.VirtualService) error {
 }
 
 func (s *shim) UpdateService(svc *types.VirtualService) error {
-	ipvsSvc, err := initIPVSService(svc.Key)
+	ipvsSvc, err := createHandleService(svc.Key)
 	if err != nil {
 		return err
 	}
 	ipvsSvc.SchedName = svc.Config.Scheduler
-	ipvsSvc.Flags, err = createFlagbits(svc.Config.Flags)
+	ipvsSvc.Flags = toFlagBits(svc.Config.Flags)
 	if err != nil {
 		return err
 	}
@@ -146,45 +99,34 @@ func (s *shim) UpdateService(svc *types.VirtualService) error {
 }
 
 func (s *shim) DeleteService(key *types.VirtualService_Key) error {
-	svc, err := initIPVSService(key)
+	svc, err := createHandleService(key)
 	if err != nil {
 		return err
 	}
 	return s.handle.DelService(svc)
 }
 
-func convertFlagbits(flagbits uint32) []string {
-	var flags []string
-	for f, v := range schedulerFlagsInverted {
-		if flagbits&f != 0 {
-			flags = append(flags, v)
-		}
-	}
-	sort.Strings(flags)
-	return flags
-}
-
 func (s *shim) ListServices() ([]*types.VirtualService, error) {
-	ipvsSvcs, err := s.handle.ListServices()
+	hServices, err := s.handle.GetServices()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to list services: %v", err)
 	}
 
 	var svcs []*types.VirtualService
-	for _, isvc := range ipvsSvcs {
-		prot, err := fromIPVSProtocol(isvc.Protocol)
+	for _, hSvc := range hServices {
+		protocol, err := fromProtocolBits(hSvc.Protocol)
 		if err != nil {
 			return nil, err
 		}
 		svc := &types.VirtualService{
 			Key: &types.VirtualService_Key{
-				Ip:       isvc.Address.String(),
-				Port:     uint32(isvc.Port),
-				Protocol: prot,
+				Ip:       hSvc.Address.String(),
+				Port:     uint32(hSvc.Port),
+				Protocol: protocol,
 			},
 			Config: &types.VirtualService_Config{
-				Scheduler: isvc.SchedName,
-				Flags:     convertFlagbits(isvc.Flags.Flags),
+				Scheduler: hSvc.SchedName,
+				Flags:     fromFlagBits(hSvc.Flags),
 			},
 		}
 		svcs = append(svcs, svc)
@@ -193,8 +135,8 @@ func (s *shim) ListServices() ([]*types.VirtualService, error) {
 	return svcs, nil
 }
 
-func createDest(server *types.RealServer, full bool) (*libipvs.Destination, error) {
-	dest := &libipvs.Destination{
+func createHandleDestination(server *types.RealServer, full bool) (*ipvs.Destination, error) {
+	dest := &ipvs.Destination{
 		Address:       net.ParseIP(server.Key.Ip),
 		Port:          uint16(server.Key.Port),
 		AddressFamily: syscall.AF_INET,
@@ -207,20 +149,20 @@ func createDest(server *types.RealServer, full bool) (*libipvs.Destination, erro
 		if !ok {
 			return nil, fmt.Errorf("invalid forwarding method %q", server.Config.Forward)
 		}
-		dest.FwdMethod = libipvs.FwdMethod(fwdbits)
+		dest.ConnectionFlags = fwdbits
 	}
 	if server.Config.Weight != nil {
-		dest.Weight = server.Config.Weight.Value
+		dest.Weight = int(server.Config.Weight.Value)
 	}
 	return dest, nil
 }
 
 func (s *shim) AddServer(key *types.VirtualService_Key, server *types.RealServer) error {
-	svc, err := initIPVSService(key)
+	svc, err := createHandleService(key)
 	if err != nil {
 		return err
 	}
-	dest, err := createDest(server, true)
+	dest, err := createHandleDestination(server, true)
 	if err != nil {
 		return err
 	}
@@ -228,11 +170,11 @@ func (s *shim) AddServer(key *types.VirtualService_Key, server *types.RealServer
 }
 
 func (s *shim) UpdateServer(key *types.VirtualService_Key, server *types.RealServer) error {
-	svc, err := initIPVSService(key)
+	svc, err := createHandleService(key)
 	if err != nil {
 		return err
 	}
-	dest, err := createDest(server, true)
+	dest, err := createHandleDestination(server, true)
 	if err != nil {
 		return err
 	}
@@ -240,11 +182,11 @@ func (s *shim) UpdateServer(key *types.VirtualService_Key, server *types.RealSer
 }
 
 func (s *shim) DeleteServer(key *types.VirtualService_Key, server *types.RealServer) error {
-	svc, err := initIPVSService(key)
+	svc, err := createHandleService(key)
 	if err != nil {
 		return err
 	}
-	dest, err := createDest(server, false)
+	dest, err := createHandleDestination(server, false)
 	if err != nil {
 		return err
 	}
@@ -252,21 +194,22 @@ func (s *shim) DeleteServer(key *types.VirtualService_Key, server *types.RealSer
 }
 
 func (s *shim) ListServers(key *types.VirtualService_Key) ([]*types.RealServer, error) {
-	svc, err := initIPVSService(key)
+	svc, err := createHandleService(key)
 	if err != nil {
 		return nil, err
 	}
 
-	dests, err := s.handle.ListDestinations(svc)
+	dests, err := s.handle.GetDestinations(svc)
 	if err != nil {
 		return nil, err
 	}
 
 	var servers []*types.RealServer
 	for _, dest := range dests {
-		fwd, ok := forwardingMethodsInverted[dest.FwdMethod]
+		fwdBits := dest.ConnectionFlags & ipvs.ConnectionFlagFwdMask
+		fwd, ok := forwardingMethodsInverted[fwdBits]
 		if !ok {
-			return nil, fmt.Errorf("unable to list backends, unexpected forward method %#x", dest.FwdMethod)
+			return nil, fmt.Errorf("unable to list backends, unexpected forward method bits %#x", fwdBits)
 		}
 		server := &types.RealServer{
 			Key: &types.RealServer_Key{
@@ -274,7 +217,7 @@ func (s *shim) ListServers(key *types.VirtualService_Key) ([]*types.RealServer, 
 				Port: uint32(dest.Port),
 			},
 			Config: &types.RealServer_Config{
-				Weight:  &wrappers.UInt32Value{Value: dest.Weight},
+				Weight:  &wrappers.UInt32Value{Value: uint32(dest.Weight)},
 				Forward: fwd,
 			},
 		}

--- a/reconciler/reconciler_test.go
+++ b/reconciler/reconciler_test.go
@@ -377,6 +377,10 @@ type ipvsMock struct {
 	mock.Mock
 }
 
+func (i *ipvsMock) Close() {
+	i.Called()
+}
+
 func (i *ipvsMock) AddService(svc *types.VirtualService) error {
 	args := i.Called(svc)
 	return args.Error(0)


### PR DESCRIPTION
There's a bug in the mqliang/libipvs library that causes all IPVS
connections to fail sporadically. Move to the more used docker/libnetwork
library to fix this. This is based on kube-router's approach - they had the
same issue (https://github.com/cloudnativelabs/kube-router/issues/78) and
moved to docker/libnetwork to fix it.