### PR TITLE
Update weight on healthcheck state change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-# 0.1.3
-
-* Update weights immediately when healthcheck state changes.
-
 # 0.1.2
 
 * Swap to github.com/docker/libnetwork for IPVS, to improve stability.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.1.3
+
+* Update weights immediately when healthcheck state changes.
+
 # 0.1.2
 
 * Swap to github.com/docker/libnetwork for IPVS, to improve stability.

--- a/reconciler/healthchecks/healthchecks.go
+++ b/reconciler/healthchecks/healthchecks.go
@@ -17,74 +17,88 @@ import (
 	"github.com/sky-uk/merlin/types"
 )
 
+// HealthState of a server.
+type HealthState bool
+
+const (
+	// ServerUp if server is healthy.
+	ServerUp HealthState = true
+	// ServerDown if server is unhealthy.
+	ServerDown HealthState = false
+)
+
+// TransitionFunc is called on a health state change.
+type TransitionFunc func(state HealthState)
+
 // Checker checks if the real servers of a virtual service are up.
 type Checker interface {
 	// IsDown returns true if the server is down.
 	IsDown(serviceID string, key *types.RealServer_Key) bool
 	// SetHealthCheck on the given server, replacing any existing health check.
-	SetHealthCheck(serviceID string, key *types.RealServer_Key, check *types.RealServer_HealthCheck) error
+	SetHealthCheck(serviceID string, key *types.RealServer_Key, check *types.RealServer_HealthCheck,
+		fn TransitionFunc) error
 	// RemHealthCheck for the given server.
 	RemHealthCheck(serviceID string, key *types.RealServer_Key)
 	// Stop all health checks. Use at shutdown.
 	Stop()
 }
 
-type infoKey struct {
+type healthCheckStateKey struct {
 	id  string
 	key types.RealServer_Key
 }
 
 type checker struct {
-	infos map[infoKey]*checkInfo
+	healthCheckStates map[healthCheckStateKey]*healthCheckState
 	sync.Mutex
 }
 
-type checkInfo struct {
+type healthCheckState struct {
+	// immutable state
 	serverIP    string
 	healthCheck *types.RealServer_HealthCheck
-	status      *checkStatus
 	stopCh      chan struct{}
+
+	// mutable state
+	status       *healthCheckStatus
+	transitionFn TransitionFunc
+	// Guards status and transitionFn which can change asynchronously.
+	sync.Mutex
 }
 
-type healthState bool
-
-const (
-	serverUp   healthState = true
-	serverDown healthState = false
-)
-
-// checkStatus keeps track of the current status of a health check for a specific real server.
+// healthCheckStatus keeps track of the current status of a health check for a specific real server.
 // state field represents the current state, either up or down.
 // count field is a state variable, whose meaning changes depending on state:
 // * up   - count is the number of failed health checks
 // * down - count is the number of successful health checks
-type checkStatus struct {
-	state healthState
+type healthCheckStatus struct {
+	state HealthState
 	count uint32
-	sync.Mutex
 }
 
 // New creates a new checker.
 func New() Checker {
-	return &checker{infos: make(map[infoKey]*checkInfo)}
+	return &checker{
+		healthCheckStates: make(map[healthCheckStateKey]*healthCheckState),
+	}
 }
 
 func (c *checker) IsDown(serviceID string, key *types.RealServer_Key) bool {
 	c.Lock()
 	defer c.Unlock()
 
-	infoKey := infoKey{id: serviceID, key: *key}
-	info, ok := c.infos[infoKey]
+	stateKey := healthCheckStateKey{id: serviceID, key: *key}
+	state, ok := c.healthCheckStates[stateKey]
 	if !ok {
-		panic(fmt.Sprintf("bug: health check not added yet: %v", infoKey))
+		panic(fmt.Sprintf("bug: health check not added yet: %v", stateKey))
 	}
-	if info.healthCheck.Endpoint.GetValue() == "" {
+	if state.healthCheck.Endpoint.GetValue() == "" {
 		return false
 	}
 
-	info.status.Lock()
-	defer info.status.Unlock()
-	return info.status.state == serverDown
+	state.Lock()
+	defer state.Unlock()
+	return state.status.state == ServerDown
 }
 
 func validateCheck(check *types.RealServer_HealthCheck) error {
@@ -107,110 +121,124 @@ func validateCheck(check *types.RealServer_HealthCheck) error {
 	return nil
 }
 
-func (c *checker) SetHealthCheck(serviceID string, key *types.RealServer_Key, check *types.RealServer_HealthCheck) error {
+func (c *checker) SetHealthCheck(serviceID string, key *types.RealServer_Key, check *types.RealServer_HealthCheck,
+	fn TransitionFunc) error {
+
 	if err := validateCheck(check); err != nil {
 		return fmt.Errorf("invalid healthcheck %v: %v", check, err)
+	}
+
+	if fn == nil {
+		fn = func(_ HealthState) {}
 	}
 
 	c.Lock()
 	defer c.Unlock()
 
-	infoKey := infoKey{id: serviceID, key: *key}
-	if info, ok := c.infos[infoKey]; ok {
-		// don't update if it's the same
-		if proto.Equal(info.healthCheck, check) {
+	status := &healthCheckStatus{
+		state: ServerDown,
+		count: 0,
+	}
+
+	stateKey := healthCheckStateKey{id: serviceID, key: *key}
+	if origState, ok := c.healthCheckStates[stateKey]; ok {
+
+		origState.Lock()
+		origState.transitionFn = fn
+		origState.Unlock()
+
+		// Don't replace health check if it's the same.
+		if proto.Equal(origState.healthCheck, check) {
 			return nil
 		}
-		c.updateHealthCheck(info, check)
-		return nil
+
+		// Stop any existing health check goroutine.
+		if origState.stopCh != nil {
+			close(origState.stopCh)
+		}
+
+		// Copy prior state into new state.
+		origState.Lock()
+		status.state = origState.status.state
+		status.count = origState.status.count
+		origState.Unlock()
 	}
 
-	info := &checkInfo{
-		serverIP:    key.Ip,
-		healthCheck: check,
-		status: &checkStatus{
-			state: serverDown,
-			count: 0,
-		},
+	state := &healthCheckState{
+		serverIP:     key.Ip,
+		healthCheck:  check,
+		status:       status,
+		transitionFn: fn,
 	}
-	c.infos[infoKey] = info
 
-	info.startBackgroundHealthCheck()
+	c.healthCheckStates[stateKey] = state
+	state.startBackgroundHealthCheck()
 	return nil
 }
 
-func (c *checker) updateHealthCheck(info *checkInfo, check *types.RealServer_HealthCheck) {
-	info.healthCheck = check
-
-	// stop any existing health check goroutine
-	if info.stopCh != nil {
-		close(info.stopCh)
-		info.stopCh = nil
-	}
-
-	// kick off new health check
-	info.startBackgroundHealthCheck()
-}
-
-func (info *checkInfo) startBackgroundHealthCheck() {
-	if info.healthCheck.Endpoint.GetValue() == "" {
+func (s *healthCheckState) startBackgroundHealthCheck() {
+	if s.healthCheck.Endpoint.GetValue() == "" {
 		// endpoint is empty, don't health check
 		return
 	}
 	stopCh := make(chan struct{})
-	info.stopCh = stopCh
-	go info.status.healthCheck(info.stopCh, info.serverIP, info.healthCheck)
+	s.stopCh = stopCh
+	go s.healthCheckLoop()
 }
 
 func (c *checker) RemHealthCheck(serviceID string, key *types.RealServer_Key) {
 	c.Lock()
 	defer c.Unlock()
 
-	infoKey := infoKey{id: serviceID, key: *key}
-	info, ok := c.infos[infoKey]
+	stateKey := healthCheckStateKey{id: serviceID, key: *key}
+	state, ok := c.healthCheckStates[stateKey]
 	if !ok {
 		// nothing to remove
 		return
 	}
 
-	if info.stopCh != nil {
-		close(info.stopCh)
+	if state.stopCh != nil {
+		close(state.stopCh)
 	}
-	delete(c.infos, infoKey)
+	delete(c.healthCheckStates, stateKey)
 }
 
 func (c *checker) Stop() {
 	c.Lock()
-	defer c.Unlock()
+	var keys []healthCheckStateKey
+	for key := range c.healthCheckStates {
+		keys = append(keys, key)
+	}
+	c.Unlock()
 
-	for _, info := range c.infos {
-		c.updateHealthCheck(info, &types.RealServer_HealthCheck{})
+	for _, key := range keys {
+		c.RemHealthCheck(key.id, &key.key)
 	}
 }
 
 // healthCheck a real server and update its status
-func (s *checkStatus) healthCheck(stopCh <-chan struct{}, serverIP string, check *types.RealServer_HealthCheck) {
-	log.Infof("Starting health check for %s: %v", serverIP, check)
+func (s *healthCheckState) healthCheckLoop() {
+	log.Infof("Starting health check for %s: %v", s.serverIP, s.healthCheck)
 
 	// perform first health check immediately
-	s.performHealthCheck(serverIP, check)
+	s.performHealthCheck()
 
-	per, _ := ptypes.Duration(check.Period)
+	per, _ := ptypes.Duration(s.healthCheck.Period)
 	t := time.NewTicker(per)
 	defer t.Stop()
 	for {
 		select {
 		case <-t.C:
-			s.performHealthCheck(serverIP, check)
-		case <-stopCh:
-			log.Infof("Stopped health check for %s", serverIP)
+			s.performHealthCheck()
+		case <-s.stopCh:
+			log.Infof("Stopped health check for %s", s.serverIP)
 			return
 		}
 	}
 }
 
-func (s *checkStatus) performHealthCheck(serverIP string, healthCheck *types.RealServer_HealthCheck) {
-	checkURL, err := url.Parse(healthCheck.Endpoint.GetValue())
+func (s *healthCheckState) performHealthCheck() {
+	checkURL, err := url.Parse(s.healthCheck.Endpoint.GetValue())
 	if err != nil {
 		panic(err)
 	}
@@ -218,11 +246,11 @@ func (s *checkStatus) performHealthCheck(serverIP string, healthCheck *types.Rea
 		panic("unsupported health check scheme " + checkURL.Scheme)
 	}
 
-	// Create a custom transport so we don't reuse prior connections, which might hide connectivity problems.
+	// Create a custom transport so we don't reuse prior connections - which might hide connectivity problems.
 	tr := &http.Transport{
 		DisableKeepAlives: true,
 	}
-	timeout, err := ptypes.Duration(healthCheck.Timeout)
+	timeout, err := ptypes.Duration(s.healthCheck.Timeout)
 	if err != nil {
 		panic(err)
 	}
@@ -231,7 +259,7 @@ func (s *checkStatus) performHealthCheck(serverIP string, healthCheck *types.Rea
 		Timeout:   timeout,
 	}
 
-	serverURL, err := url.Parse(fmt.Sprintf("http://%s:%s%s", serverIP, checkURL.Port(), checkURL.Path))
+	serverURL, err := url.Parse(fmt.Sprintf("http://%s:%s%s", s.serverIP, checkURL.Port(), checkURL.Path))
 	if err != nil {
 		panic(err)
 	}
@@ -239,45 +267,49 @@ func (s *checkStatus) performHealthCheck(serverIP string, healthCheck *types.Rea
 	resp, err := client.Get(serverURL.String())
 	if err != nil {
 		log.Infof("%s inaccessible: %v", serverURL, err)
-		s.incrementDown(healthCheck)
+		s.incrementDown()
 		return
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || 300 <= resp.StatusCode {
 		body, _ := ioutil.ReadAll(resp.Body)
 		log.Infof("%s returned %d: %s", serverURL, resp.StatusCode, string(body))
-		s.incrementDown(healthCheck)
+		s.incrementDown()
 		return
 	}
-	s.incrementUp(healthCheck)
+	s.incrementUp()
 }
 
-func (s *checkStatus) incrementUp(healthCheck *types.RealServer_HealthCheck) {
+func (s *healthCheckState) incrementUp() {
 	s.Lock()
 	defer s.Unlock()
-	switch s.state {
-	case serverDown:
-		s.count++
-		if s.count >= healthCheck.UpThreshold {
-			s.state = serverUp
-			s.count = 0
+	status := s.status
+	switch status.state {
+	case ServerDown:
+		status.count++
+		if status.count >= s.healthCheck.UpThreshold {
+			status.state = ServerUp
+			status.count = 0
+			s.transitionFn(status.state)
 		}
-	case serverUp:
-		s.count = 0
+	case ServerUp:
+		status.count = 0
 	}
 }
 
-func (s *checkStatus) incrementDown(healthCheck *types.RealServer_HealthCheck) {
+func (s *healthCheckState) incrementDown() {
 	s.Lock()
 	defer s.Unlock()
-	switch s.state {
-	case serverDown:
-		s.count = 0
-	case serverUp:
-		s.count++
-		if s.count >= healthCheck.DownThreshold {
-			s.state = serverDown
-			s.count = 0
+	status := s.status
+	switch status.state {
+	case ServerDown:
+		status.count = 0
+	case ServerUp:
+		status.count++
+		if status.count >= s.healthCheck.DownThreshold {
+			status.state = ServerDown
+			status.count = 0
+			s.transitionFn(status.state)
 		}
 	}
 }

--- a/reconciler/healthchecks/healthchecks_test.go
+++ b/reconciler/healthchecks/healthchecks_test.go
@@ -1,14 +1,15 @@
 package healthchecks
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 	"time"
 
 	"sync"
+
+	"fmt"
+	"net/url"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
@@ -42,6 +43,8 @@ func getServerStatus() int {
 	return serverStatus
 }
 
+func stubTransitionFn(_ HealthState) {}
+
 var _ = Describe("HealthChecks", func() {
 	var (
 		serviceID                               = "myservice"
@@ -59,9 +62,7 @@ var _ = Describe("HealthChecks", func() {
 		checker = New()
 		period = 50 * time.Millisecond
 		timeout = 20 * time.Millisecond
-	})
 
-	JustBeforeEach(func() {
 		ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path != checkPath {
 				w.WriteHeader(http.StatusNotFound)
@@ -88,19 +89,20 @@ var _ = Describe("HealthChecks", func() {
 		ts.Close()
 	})
 
-	It("should report server is down if non-responsive", func() {
+	It("should report server is down if non-responsive", func(done Done) {
 		checker := New()
 		check.Endpoint = &wrappers.StringValue{Value: "http://:9999/nowhere"}
-		checker.SetHealthCheck(serviceID, localServer1, check)
+		checker.SetHealthCheck(serviceID, localServer1, check, stubTransitionFn)
 
 		time.Sleep(waitForDown)
 		Expect(checker.IsDown(serviceID, localServer1)).To(BeTrue())
-	})
+		close(done)
+	}, 1.0)
 
 	DescribeTable("validate health check", func(endpoint string) {
 		checker := New()
 		check.Endpoint = &wrappers.StringValue{Value: endpoint}
-		err := checker.SetHealthCheck(serviceID, localServer1, check)
+		err := checker.SetHealthCheck(serviceID, localServer1, check, stubTransitionFn)
 		Expect(err).To(HaveOccurred())
 	},
 		Entry("unsupported scheme", "myscheme://:9111/health"),
@@ -111,23 +113,25 @@ var _ = Describe("HealthChecks", func() {
 			setServerStatus(http.StatusOK)
 		})
 
-		It("should not list servers in down IPs", func() {
-			checker.SetHealthCheck(serviceID, localServer1, check)
-			checker.SetHealthCheck(serviceID, localServer2, check)
+		It("should not list servers in down IPs", func(done Done) {
+			checker.SetHealthCheck(serviceID, localServer1, check, stubTransitionFn)
+			checker.SetHealthCheck(serviceID, localServer2, check, stubTransitionFn)
 
 			time.Sleep(waitForUp)
 			Expect(checker.IsDown(serviceID, localServer1)).To(BeFalse())
 			Expect(checker.IsDown(serviceID, localServer2)).To(BeFalse())
-		})
+			close(done)
+		}, 1.0)
 
-		It("should consider server down before health check happens", func() {
-			checker.SetHealthCheck(serviceID, localServer1, check)
+		It("should consider server down before health check happens", func(done Done) {
+			checker.SetHealthCheck(serviceID, localServer1, check, stubTransitionFn)
 
 			Expect(checker.IsDown(serviceID, localServer1)).To(BeTrue())
-		})
+			close(done)
+		}, 1.0)
 
-		It("can transition to down and back up", func() {
-			checker.SetHealthCheck(serviceID, localServer1, check)
+		It("can transition to down and back up", func(done Done) {
+			checker.SetHealthCheck(serviceID, localServer1, check, stubTransitionFn)
 			time.Sleep(waitForUp)
 
 			setServerStatus(http.StatusInternalServerError)
@@ -137,44 +141,48 @@ var _ = Describe("HealthChecks", func() {
 			setServerStatus(http.StatusOK)
 			time.Sleep(waitForUp)
 			Expect(checker.IsDown(serviceID, localServer1)).To(BeFalse())
+			close(done)
 		})
 
-		It("can update to a passing health check", func() {
+		It("can update to a passing health check", func(done Done) {
 			brokenCheck := proto.Clone(check).(*types.RealServer_HealthCheck)
 			brokenCheck.Endpoint = &wrappers.StringValue{Value: "http://:9999/nowhere"}
-			checker.SetHealthCheck(serviceID, localServer1, brokenCheck)
+			checker.SetHealthCheck(serviceID, localServer1, brokenCheck, stubTransitionFn)
 
 			time.Sleep(waitForUp)
 			Expect(checker.IsDown(serviceID, localServer1)).To(BeTrue())
 
-			checker.SetHealthCheck(serviceID, localServer1, check)
+			checker.SetHealthCheck(serviceID, localServer1, check, stubTransitionFn)
 			time.Sleep(waitForUp)
 			Expect(checker.IsDown(serviceID, localServer1)).To(BeFalse())
-		})
+			close(done)
+		}, 1.0)
 
-		It("can remove then add back the server", func() {
-			checker.SetHealthCheck(serviceID, localServer1, check)
+		It("can remove then add back the server", func(done Done) {
+			checker.SetHealthCheck(serviceID, localServer1, check, stubTransitionFn)
 			checker.RemHealthCheck(serviceID, localServer1)
 			time.Sleep(waitForUp)
 			checker.RemHealthCheck(serviceID, localServer1)
-			checker.SetHealthCheck(serviceID, localServer1, check)
+			checker.SetHealthCheck(serviceID, localServer1, check, stubTransitionFn)
 			Expect(checker.IsDown(serviceID, localServer1)).To(BeTrue())
 			time.Sleep(waitForUp)
 			Expect(checker.IsDown(serviceID, localServer1)).To(BeFalse())
-		})
+			close(done)
+		}, 1.0)
 
-		It("should keep the server state if we set the same health check", func() {
-			checker.SetHealthCheck(serviceID, localServer1, check)
+		It("should keep the server state if we set the same health check", func(done Done) {
+			checker.SetHealthCheck(serviceID, localServer1, check, stubTransitionFn)
 
 			time.Sleep(waitForUp)
 			Expect(checker.IsDown(serviceID, localServer1)).To(BeFalse())
 
-			checker.SetHealthCheck(serviceID, localServer1, check)
+			checker.SetHealthCheck(serviceID, localServer1, check, stubTransitionFn)
 			Expect(checker.IsDown(serviceID, localServer1)).To(BeFalse())
-		})
+			close(done)
+		}, 1.0)
 
-		It("should be able to update the health check", func() {
-			checker.SetHealthCheck(serviceID, localServer1, check)
+		It("should be able to update the health check", func(done Done) {
+			checker.SetHealthCheck(serviceID, localServer1, check, stubTransitionFn)
 
 			time.Sleep(waitForUp)
 			Expect(checker.IsDown(serviceID, localServer1)).To(BeFalse())
@@ -182,13 +190,14 @@ var _ = Describe("HealthChecks", func() {
 			check2 := proto.Clone(check).(*types.RealServer_HealthCheck)
 			check2.DownThreshold = 1
 			check2.Endpoint = &wrappers.StringValue{Value: "http://localhost:99999/nowhere"}
-			checker.SetHealthCheck(serviceID, localServer1, check2)
+			checker.SetHealthCheck(serviceID, localServer1, check2, stubTransitionFn)
 			Expect(checker.IsDown(serviceID, localServer1)).To(BeFalse(), "nothing should change immediately after setting check")
 
 			// wait one period, since down threshold is 1 now
 			time.Sleep(period + timeout)
 			Expect(checker.IsDown(serviceID, localServer1)).To(BeTrue())
-		})
+			close(done)
+		}, 1.0)
 	})
 
 	Context("server is down", func() {
@@ -196,17 +205,18 @@ var _ = Describe("HealthChecks", func() {
 			setServerStatus(http.StatusInternalServerError)
 		})
 
-		It("should list server in down IPs", func() {
-			checker.SetHealthCheck(serviceID, localServer1, check)
-			checker.SetHealthCheck(serviceID, localServer2, check)
+		It("should list server in down IPs", func(done Done) {
+			checker.SetHealthCheck(serviceID, localServer1, check, stubTransitionFn)
+			checker.SetHealthCheck(serviceID, localServer2, check, stubTransitionFn)
 
 			time.Sleep(waitForDown)
 			Expect(checker.IsDown(serviceID, localServer1)).To(BeTrue())
 			Expect(checker.IsDown(serviceID, localServer2)).To(BeTrue())
-		})
+			close(done)
+		}, 1.0)
 
-		It("can transition to up and back down", func() {
-			checker.SetHealthCheck(serviceID, localServer1, check)
+		It("can transition to up and back down", func(done Done) {
+			checker.SetHealthCheck(serviceID, localServer1, check, stubTransitionFn)
 			time.Sleep(waitForDown)
 			Expect(checker.IsDown(serviceID, localServer1)).To(BeTrue())
 
@@ -217,22 +227,116 @@ var _ = Describe("HealthChecks", func() {
 			setServerStatus(http.StatusInternalServerError)
 			time.Sleep(waitForDown)
 			Expect(checker.IsDown(serviceID, localServer1)).To(BeTrue())
-		})
+			close(done)
+		}, 1.0)
 
-		It("should no longer report down after disabling health check", func() {
-			checker.SetHealthCheck(serviceID, localServer1, check)
+		It("should no longer report down after disabling health check", func(done Done) {
+			checker.SetHealthCheck(serviceID, localServer1, check, stubTransitionFn)
 			time.Sleep(waitForDown)
 			Expect(checker.IsDown(serviceID, localServer1)).To(BeTrue())
 
 			By("removing the health check", func() {
-				checker.SetHealthCheck(serviceID, localServer1, &types.RealServer_HealthCheck{})
+				checker.SetHealthCheck(serviceID, localServer1, &types.RealServer_HealthCheck{}, stubTransitionFn)
 				Expect(checker.IsDown(serviceID, localServer1)).To(BeFalse())
 			})
 
 			By("re-adding the health check", func() {
-				checker.SetHealthCheck(serviceID, localServer1, check)
+				checker.SetHealthCheck(serviceID, localServer1, check, stubTransitionFn)
 				Expect(checker.IsDown(serviceID, localServer1)).To(BeTrue())
 			})
+			close(done)
+		}, 1.0)
+	})
+
+	Context("transition function", func() {
+		var (
+			called        bool
+			receivedState HealthState
+			lock          *sync.Mutex
+		)
+
+		BeforeEach(func() {
+			called = false
+			receivedState = ServerDown
+			lock = &sync.Mutex{}
+			checker.SetHealthCheck(serviceID, localServer1, check, func(state HealthState) {
+				lock.Lock()
+				defer lock.Unlock()
+				called = true
+				receivedState = state
+			})
+		})
+
+		It("should be invoked when transitioning from up to down", func() {
+			setServerStatus(http.StatusOK)
+
+			time.Sleep(waitForUp)
+			func() {
+				lock.Lock()
+				defer lock.Unlock()
+				Expect(called).To(BeTrue())
+				Expect(receivedState).To(Equal(ServerUp))
+				called = false
+			}()
+
+			setServerStatus(http.StatusInternalServerError)
+			time.Sleep(waitForDown)
+			func() {
+				lock.Lock()
+				defer lock.Unlock()
+				Expect(called).To(BeTrue())
+				Expect(receivedState).To(Equal(ServerDown))
+			}()
+		})
+
+		It("should be invoked when transitioning from down to up", func() {
+			setServerStatus(http.StatusInternalServerError)
+
+			time.Sleep(waitForDown)
+			func() {
+				lock.Lock()
+				defer lock.Unlock()
+				Expect(called).To(BeFalse())
+			}()
+
+			setServerStatus(http.StatusOK)
+			time.Sleep(waitForUp)
+			func() {
+				lock.Lock()
+				defer lock.Unlock()
+				Expect(called).To(BeTrue())
+				Expect(receivedState).To(Equal(ServerUp))
+			}()
+		})
+
+		It("can be updated", func() {
+			setServerStatus(http.StatusOK)
+			var updatedCalled bool
+
+			checker.SetHealthCheck(serviceID, localServer1, check, func(_ HealthState) {
+				lock.Lock()
+				defer lock.Unlock()
+				updatedCalled = true
+			})
+
+			time.Sleep(waitForUp)
+			func() {
+				lock.Lock()
+				defer lock.Unlock()
+				Expect(called).To(BeFalse(), "old transition func should not be called")
+				Expect(updatedCalled).To(BeTrue(), "new transition func should be called")
+			}()
+		})
+
+		It("nil transition func can be used", func() {
+			setServerStatus(http.StatusOK)
+			checker.SetHealthCheck(serviceID, localServer1, check, nil)
+			time.Sleep(waitForUp)
+			func() {
+				lock.Lock()
+				defer lock.Unlock()
+				Expect(called).To(BeFalse(), "old transition func should not be called")
+			}()
 		})
 	})
 })

--- a/reconciler/healthchecks/healthchecks_test.go
+++ b/reconciler/healthchecks/healthchecks_test.go
@@ -43,7 +43,7 @@ func getServerStatus() int {
 	return serverStatus
 }
 
-func stubTransitionFn(_ HealthState) {}
+func stubTransitionFn(_ ServerStatus) {}
 
 var _ = Describe("HealthChecks", func() {
 	var (
@@ -251,7 +251,7 @@ var _ = Describe("HealthChecks", func() {
 	Context("transition function", func() {
 		var (
 			called        bool
-			receivedState HealthState
+			receivedState ServerStatus
 			lock          *sync.Mutex
 		)
 
@@ -259,7 +259,7 @@ var _ = Describe("HealthChecks", func() {
 			called = false
 			receivedState = ServerDown
 			lock = &sync.Mutex{}
-			checker.SetHealthCheck(serviceID, localServer1, check, func(state HealthState) {
+			checker.SetHealthCheck(serviceID, localServer1, check, func(state ServerStatus) {
 				lock.Lock()
 				defer lock.Unlock()
 				called = true
@@ -313,7 +313,7 @@ var _ = Describe("HealthChecks", func() {
 			setServerStatus(http.StatusOK)
 			var updatedCalled bool
 
-			checker.SetHealthCheck(serviceID, localServer1, check, func(_ HealthState) {
+			checker.SetHealthCheck(serviceID, localServer1, check, func(_ ServerStatus) {
 				lock.Lock()
 				defer lock.Unlock()
 				updatedCalled = true

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -94,11 +94,35 @@ func (r *reconciler) initializeHealthChecks() error {
 			return fmt.Errorf("failed to query store when initializing: %v", err)
 		}
 		for _, server := range servers {
-			r.checker.SetHealthCheck(server.ServiceID, server.Key, server.HealthCheck)
+			fn := r.createHealthStateWeightUpdater(service.Key, server)
+			r.checker.SetHealthCheck(server.ServiceID, server.Key, server.HealthCheck, fn)
 		}
 	}
 
 	return nil
+}
+
+func (r *reconciler) createHealthStateWeightUpdater(serviceKey *types.VirtualService_Key,
+	originalServer *types.RealServer) healthchecks.TransitionFunc {
+
+	// clone the original server, to protect against external mutation
+	server := proto.Clone(originalServer).(*types.RealServer)
+
+	return func(state healthchecks.HealthState) {
+		serverCopy := proto.Clone(server).(*types.RealServer)
+		switch state {
+		case healthchecks.ServerDown:
+			serverCopy.Config.Weight = &wrappers.UInt32Value{Value: 0}
+		case healthchecks.ServerUp:
+			// change nothing - restore the original weight
+		default:
+			panic("unexpected state")
+		}
+
+		if err := r.ipvs.UpdateServer(serviceKey, serverCopy); err != nil {
+			log.Warnf("Unable to update the weight for %v: %v", serverCopy, err)
+		}
+	}
 }
 
 func (r *reconciler) Stop() {
@@ -174,7 +198,8 @@ func (r *reconciler) reconcile() {
 			}
 
 			// update health check
-			r.checker.SetHealthCheck(desiredServer.ServiceID, desiredServer.Key, desiredServer.HealthCheck)
+			fn := r.createHealthStateWeightUpdater(desiredService.Key, desiredServer)
+			r.checker.SetHealthCheck(desiredServer.ServiceID, desiredServer.Key, desiredServer.HealthCheck, fn)
 			if r.checker.IsDown(desiredServer.ServiceID, desiredServer.Key) {
 				desiredServer.Config.Weight = &wrappers.UInt32Value{Value: 0}
 			}

--- a/reconciler/reconciler.go
+++ b/reconciler/reconciler.go
@@ -108,7 +108,7 @@ func (r *reconciler) createHealthStateWeightUpdater(serviceKey *types.VirtualSer
 	// clone the original server, to protect against external mutation
 	server := proto.Clone(originalServer).(*types.RealServer)
 
-	return func(state healthchecks.HealthState) {
+	return func(state healthchecks.ServerStatus) {
 		serverCopy := proto.Clone(server).(*types.RealServer)
 		switch state {
 		case healthchecks.ServerDown:


### PR DESCRIPTION
Rather than on sync only, update the weight immediately when server
state goes up or down.