### PR TITLE
Fix ipvs initialisation

### DIFF
--- a/ipvs/shim.go
+++ b/ipvs/shim.go
@@ -45,7 +45,7 @@ type shim struct {
 
 // New IPVS shim. This creates an underlying netlink socket. Call Close() to release the associated resources.
 func New() (IPVS, error) {
-	h, err := ipvs.New("/")
+	h, err := ipvs.New("")
 	if err != nil {
 		return nil, fmt.Errorf("unable to init ipvs: %v", err)
 	}


### PR DESCRIPTION
Don't use a path to avoid trying to look up the network namespace.