### PR TITLE
Add etcd3 store backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.0
+
+* Add support for etcd3 storage backend
+* Add `store-backend` command line switch to allow storage backend to use etcd2 or etcd3. Defaults to etcd2.
+
 # 0.1.4
 
 * Add netlink timeouts to guard against a hanging reconciler.

--- a/README.md
+++ b/README.md
@@ -81,5 +81,4 @@ Testing should be done with [gingko](http://onsi.github.io/ginkgo/)/[gomega](htt
 
 # Remaining features
 
-* etcd3 with watchers
 * bgp client for ECMP

--- a/cmd/merlin/main.go
+++ b/cmd/merlin/main.go
@@ -40,6 +40,7 @@ var (
 	debugLogs           bool
 	port                int
 	healthPort          int
+	storeBackend        string
 	storeEndpoints      string
 	storePrefix         string
 	reconcileSyncPeriod time.Duration
@@ -57,7 +58,8 @@ func init() {
 	f.BoolVar(&debugLogs, "debug", false, "enable debug logs")
 	f.IntVar(&port, "port", 4282, "server port")
 	f.IntVar(&healthPort, "health-port", 4283, "/health, /alive, /metrics, and /debug endpoints")
-	f.StringVar(&storeEndpoints, "store-endpoints", "", "comma delimited list of etcd2 endpoints")
+	f.StringVar(&storeBackend, "store-backend", "etcd2", "controls which storage backend to use; supports etcd2 or etcd3")
+	f.StringVar(&storeEndpoints, "store-endpoints", "", "comma delimited list of etcd2 / etcd3 endpoints")
 	f.StringVar(&storePrefix, "store-prefix", "/merlin", "prefix to store state")
 	f.DurationVar(&reconcileSyncPeriod, "reconcile-sync-period", time.Minute, "how often to periodically sync ipvs state")
 	f.BoolVar(&reconcile, "reconcile", true, "if enabled, merlin will reconcile local ipvs with store state")
@@ -105,7 +107,7 @@ func (s *srv) Start() {
 	}
 	log.Infof("Starting merlin")
 
-	etcdStore, err := store.NewEtcd2(strings.Split(storeEndpoints, ","), storePrefix)
+	etcdStore, err := store.NewStore(storeBackend, strings.Split(storeEndpoints, ","), storePrefix)
 	if err != nil {
 		log.Fatalf("Unable to start store client: %v", err)
 	}

--- a/e2e/api/api_test.go
+++ b/e2e/api/api_test.go
@@ -28,10 +28,7 @@ func TestE2EAPI(t *testing.T) {
 	RunSpecs(t, "E2E API Suite")
 }
 
-var _ = Describe("API", func() {
-	BeforeSuite(func() {
-		SetupE2E()
-	})
+func testApi(storeBackend string) {
 
 	var (
 		conn       *grpc.ClientConn
@@ -51,7 +48,7 @@ var _ = Describe("API", func() {
 
 	BeforeEach(func() {
 		StartEtcd()
-		StartMerlin()
+		StartMerlin(storeBackend)
 
 		dest := fmt.Sprintf("localhost:%s", MerlinPort())
 		fmt.Fprintf(os.Stderr, "dialing %s\n", dest)
@@ -513,5 +510,20 @@ var _ = Describe("API", func() {
 				}),
 			)
 		})
+	})
+}
+
+var _ = Describe("API", func() {
+
+	BeforeSuite(func() {
+		SetupE2E()
+	})
+
+	Describe("etcd2 backend", func() {
+		testApi("etcd2")
+	})
+
+	Describe("etcd3 backend", func() {
+		testApi("etcd3")
 	})
 })

--- a/e2e/api/api_test.go
+++ b/e2e/api/api_test.go
@@ -29,7 +29,6 @@ func TestE2EAPI(t *testing.T) {
 }
 
 func testApi(storeBackend string) {
-
 	var (
 		conn       *grpc.ClientConn
 		client     types.MerlinClient
@@ -514,7 +513,6 @@ func testApi(storeBackend string) {
 }
 
 var _ = Describe("API", func() {
-
 	BeforeSuite(func() {
 		SetupE2E()
 	})

--- a/e2e/cli/e2e_test.go
+++ b/e2e/cli/e2e_test.go
@@ -197,7 +197,6 @@ func testCli(storeBackend string, etcdDel func(string)) {
 }
 
 var _ = Describe("E2E With Meradm/Merlin/Etcd", func() {
-
 	BeforeSuite(func() {
 		SetupE2E()
 	})
@@ -219,9 +218,7 @@ var _ = Describe("E2E With Meradm/Merlin/Etcd", func() {
 	})
 
 	Describe("etcd3 backend", func() {
-
 		etcdDel := func(path string) {
-
 			serverURL := fmt.Sprintf("http://localhost:%s", EtcdPort())
 			keyName := fmt.Sprintf("/merlin/%s", path)
 

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -28,9 +28,10 @@ import (
 )
 
 const (
-	etcdDownloadURL    = "https://github.com/coreos/etcd/releases/download/v2.3.8/etcd-v2.3.8-linux-amd64.tar.gz"
-	etcdExpandedPath   = "etcd-v2.3.8-linux-amd64/"
-	etcdDownloadSha256 = "3431112f97105733aabb95816df99e44beabed2cc96201679e3b3b830ac35282"
+	etcdDownloadURL    = "https://github.com/coreos/etcd/releases/download/v3.3.9/etcd-v3.3.9-linux-amd64.tar.gz"
+	etcdExpandedPath   = "etcd-v3.3.9-linux-amd64/"
+	etcdDownloadSha256 = "7b95bdc6dfd1d805f650ea8f886fdae6e7322f886a8e9d1b0d14603767d053b1"
+
 	// assumes all specs run in subfolders of e2e
 	workingDir = "../.."
 	buildDir   = workingDir + "/build"
@@ -178,7 +179,7 @@ func MerlinStderr() []string {
 	return strings.Split(string(s), "\n")
 }
 
-func StartMerlin() {
+func StartMerlin(storeBackend string) {
 	ports := findFreePorts(2)
 	merlinPort = strconv.Itoa(ports[0])
 	merlinHealthPort = strconv.Itoa(ports[1])
@@ -187,6 +188,7 @@ func StartMerlin() {
 		"--port="+merlinPort,
 		"--health-port="+merlinHealthPort,
 		"--store-endpoints=http://127.0.0.1:"+etcdListenPort,
+		"--store-backend="+storeBackend,
 		"--reconcile=false",
 		"--debug")
 

--- a/store/etcd2_store.go
+++ b/store/etcd2_store.go
@@ -90,7 +90,7 @@ func (s *etcd2store) GetService(ctx context.Context, serviceID string) (*types.V
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve service from store: %v", err)
 	}
-	svc := unmarshalService(unmarshalString(resp.Node.Value))
+	svc := unmarshalService(base64decode(resp.Node.Value))
 	return svc, nil
 }
 
@@ -133,7 +133,7 @@ func (s *etcd2store) GetServer(ctx context.Context, serviceID string, key *types
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve server from store: %v", err)
 	}
-	server := unmarshalServer(unmarshalString(resp.Node.Value))
+	server := unmarshalServer(base64decode(resp.Node.Value))
 	return server, nil
 }
 
@@ -170,7 +170,7 @@ func (s *etcd2store) ListServices(ctx context.Context) ([]*types.VirtualService,
 
 	var services []*types.VirtualService
 	for _, node := range resp.Node.Nodes {
-		service := unmarshalService(unmarshalString(node.Value))
+		service := unmarshalService(base64decode(node.Value))
 		services = append(services, service)
 	}
 	return services, nil
@@ -187,7 +187,7 @@ func (s *etcd2store) ListServers(ctx context.Context, serviceID string) ([]*type
 
 	var servers []*types.RealServer
 	for _, node := range resp.Node.Nodes {
-		server := unmarshalServer(unmarshalString(node.Value))
+		server := unmarshalServer(base64decode(node.Value))
 		servers = append(servers, server)
 	}
 	return servers, nil

--- a/store/etcd2_store.go
+++ b/store/etcd2_store.go
@@ -1,0 +1,246 @@
+package store
+
+import (
+	"context"
+	"time"
+
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"github.com/cenkalti/backoff"
+	"github.com/coreos/etcd/client"
+	"github.com/golang/protobuf/proto"
+	log "github.com/sirupsen/logrus"
+	"github.com/sky-uk/merlin/types"
+)
+
+type etcd2store struct {
+	c       client.Client
+	prefix  string
+	kapi    client.KeysAPI
+	getOpts *client.GetOptions
+}
+
+// NewEtcd2 returns a Store implementation using an etcd2 backing store.
+func NewEtcd2(endpoints []string, prefix string) (Store, error) {
+	cfg := client.Config{
+		Endpoints:               endpoints,
+		Transport:               client.DefaultTransport,
+		HeaderTimeoutPerRequest: time.Second,
+	}
+	log.Debug("Creating etcd2 client")
+	c, err := client.New(cfg)
+	if err != nil {
+		return nil, err
+	}
+	s := &etcd2store{c: c, prefix: prefix, kapi: client.NewKeysAPI(c), getOpts: &client.GetOptions{Quorum: true}}
+
+	return s, s.init()
+}
+
+func (s *etcd2store) init() error {
+	if !strings.HasPrefix(s.prefix, "/") {
+		s.prefix = "/" + s.prefix
+	}
+
+	// initialize prefix directory
+	if err := s.initDir(s.prefix); err != nil {
+		return fmt.Errorf("failed to create %s directory: %v", s.prefix, err)
+	}
+
+	// initialize services directory
+	if err := s.initDir(s.prefix + services); err != nil {
+		return fmt.Errorf("failed to create %s%s directory: %v", s.prefix, services, err)
+	}
+
+	// initialize servers directory
+	if err := s.initDir(s.prefix + servers); err != nil {
+		return fmt.Errorf("failed to create %s%s directory: %v", s.prefix, servers, err)
+	}
+
+	return nil
+}
+
+func (s *etcd2store) initDir(dir string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	opts := client.SetOptions{Dir: true}
+
+	_, err := s.kapi.Get(ctx, dir, nil)
+	if !client.IsKeyNotFound(err) {
+		return err
+	}
+
+	if _, err := s.kapi.Set(ctx, dir, "", &opts); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *etcd2store) serviceKey(id string) string {
+	return s.prefix + services + "/" + id
+}
+
+func (s *etcd2store) GetService(ctx context.Context, serviceID string) (*types.VirtualService, error) {
+	resp, err := s.kapi.Get(ctx, s.serviceKey(serviceID), s.getOpts)
+	if client.IsKeyNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve service from store: %v", err)
+	}
+	svc := unmarshalService(unmarshalString(resp.Node.Value))
+	return svc, nil
+}
+
+func (s *etcd2store) PutService(ctx context.Context, service *types.VirtualService) error {
+	b, err := proto.Marshal(service)
+	if err != nil {
+		panic(err)
+	}
+
+	enc := base64.StdEncoding.EncodeToString(b)
+	if _, err := s.kapi.Set(ctx, s.serviceKey(service.Id), enc, nil); err != nil {
+		return fmt.Errorf("unable to store service %s: %v", service.Id, err)
+	}
+
+	return nil
+}
+
+func (s *etcd2store) DeleteService(ctx context.Context, serviceID string) error {
+	_, err := s.kapi.Delete(ctx, s.serviceKey(serviceID), nil)
+	return err
+}
+
+func (s *etcd2store) serverDir(serviceID string) string {
+	return s.prefix + servers + "/" + serviceID
+}
+
+func (s *etcd2store) serverKey(serviceID string, key *types.RealServer_Key) string {
+	return fmt.Sprintf("%s/%s:%d", s.serverDir(serviceID), key.Ip, key.Port)
+}
+
+func (s *etcd2store) GetServer(ctx context.Context, serviceID string, key *types.RealServer_Key) (*types.RealServer, error) {
+	if key == nil {
+		// can't retrieve server without a key
+		return nil, nil
+	}
+	resp, err := s.kapi.Get(ctx, s.serverKey(serviceID, key), s.getOpts)
+	if client.IsKeyNotFound(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve server from store: %v", err)
+	}
+	server := unmarshalServer(unmarshalString(resp.Node.Value))
+	return server, nil
+}
+
+func (s *etcd2store) PutServer(ctx context.Context, server *types.RealServer) error {
+	if err := s.initDir(s.serverDir(server.ServiceID)); err != nil {
+		return fmt.Errorf("unable to init %s/%s: %v", servers, server.ServiceID, err)
+	}
+
+	b, err := proto.Marshal(server)
+	if err != nil {
+		panic(err)
+	}
+
+	enc := base64.StdEncoding.EncodeToString(b)
+	key := s.serverKey(server.ServiceID, server.Key)
+	if _, err := s.kapi.Set(ctx, key, enc, nil); err != nil {
+		return fmt.Errorf("unable to store server %s: %v", key, err)
+	}
+
+	return nil
+}
+
+func (s *etcd2store) DeleteServer(ctx context.Context, serviceID string, key *types.RealServer_Key) error {
+	serverKey := s.serverKey(serviceID, key)
+	_, err := s.kapi.Delete(ctx, serverKey, nil)
+	return err
+}
+
+func (s *etcd2store) ListServices(ctx context.Context) ([]*types.VirtualService, error) {
+	resp, err := s.kapi.Get(ctx, s.serviceKey(""), s.getOpts)
+	if err != nil {
+		return nil, fmt.Errorf("unable to list services: %v", err)
+	}
+
+	var services []*types.VirtualService
+	for _, node := range resp.Node.Nodes {
+		service := unmarshalService(unmarshalString(node.Value))
+		services = append(services, service)
+	}
+	return services, nil
+}
+
+func (s *etcd2store) ListServers(ctx context.Context, serviceID string) ([]*types.RealServer, error) {
+	resp, err := s.kapi.Get(ctx, s.serverDir(serviceID), s.getOpts)
+	if client.IsKeyNotFound(err) {
+		return []*types.RealServer{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("unable to list servers for %s: %v", serviceID, err)
+	}
+
+	var servers []*types.RealServer
+	for _, node := range resp.Node.Nodes {
+		server := unmarshalServer(unmarshalString(node.Value))
+		servers = append(servers, server)
+	}
+	return servers, nil
+}
+
+func (s *etcd2store) Subscribe(subscriber func(), stopCh <-chan struct{}) {
+	options := &client.WatcherOptions{
+		Recursive: true,
+	}
+	watcher := s.kapi.Watcher(s.prefix, options)
+	respCh := make(chan *client.Response)
+
+	go func() {
+		ctx, cancelFunc := context.WithCancel(context.Background())
+		defer cancelFunc()
+		s.handleWatcherUpdates(ctx, watcher, respCh)
+
+		for {
+			select {
+			case <-respCh:
+				subscriber()
+			case <-stopCh:
+				return
+			}
+		}
+	}()
+}
+
+func (s *etcd2store) handleWatcherUpdates(ctx context.Context, watcher client.Watcher, respCh chan<- *client.Response) {
+	handler := func() error {
+		resp, err := watcher.Next(ctx)
+		if err == nil {
+			respCh <- resp
+		} else {
+			if ctx.Err() != nil {
+				// context was cancelled, exit handler
+				return &backoff.PermanentError{Err: err}
+			}
+			log.Warnf("etcd watcher: %v", err)
+		}
+		return err
+	}
+
+	expBackoff := backoff.NewExponentialBackOff()
+	// never stop retrying
+	expBackoff.MaxElapsedTime = 0
+
+	go func() {
+		for {
+			err := backoff.Retry(handler, expBackoff)
+			if err != nil {
+				break
+			}
+		}
+	}()
+}

--- a/store/etcd3_store.go
+++ b/store/etcd3_store.go
@@ -2,16 +2,15 @@ package store
 
 import (
 	"context"
-
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/cenkalti/backoff"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/golang/protobuf/proto"
 	log "github.com/sirupsen/logrus"
 	"github.com/sky-uk/merlin/types"
-	"time"
 )
 
 type etcd3store struct {

--- a/store/etcd3_store.go
+++ b/store/etcd3_store.go
@@ -11,6 +11,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	log "github.com/sirupsen/logrus"
 	"github.com/sky-uk/merlin/types"
+	"time"
 )
 
 type etcd3store struct {
@@ -21,7 +22,8 @@ type etcd3store struct {
 // NewEtcd3 returns a Store implementation using an etcd3 backing store.
 func NewEtcd3(endpoints []string, prefix string) (Store, error) {
 	cfg := clientv3.Config{
-		Endpoints: endpoints,
+		Endpoints:   endpoints,
+		DialTimeout: time.Second,
 	}
 	log.Debug("Creating etcd3 client")
 	c, err := clientv3.New(cfg)

--- a/store/etcd3_store.go
+++ b/store/etcd3_store.go
@@ -1,0 +1,204 @@
+package store
+
+import (
+	"context"
+
+	"fmt"
+	"strings"
+
+	"github.com/cenkalti/backoff"
+	"github.com/coreos/etcd/client"
+	"github.com/coreos/etcd/clientv3"
+	"github.com/golang/protobuf/proto"
+	log "github.com/sirupsen/logrus"
+	"github.com/sky-uk/merlin/types"
+)
+
+type etcd3store struct {
+	client *clientv3.Client
+	prefix string
+}
+
+// NewEtcd3 returns a Store implementation using an etcd3 backing store.
+func NewEtcd3(endpoints []string, prefix string) (Store, error) {
+	cfg := clientv3.Config{
+		Endpoints: endpoints,
+	}
+	log.Debug("Creating etcd3 client")
+	c, err := clientv3.New(cfg)
+	if err != nil {
+		return nil, err
+	}
+	s := &etcd3store{client: c, prefix: prefix}
+
+	return s, s.init()
+}
+
+func (s *etcd3store) init() error {
+	if !strings.HasPrefix(s.prefix, "/") {
+		s.prefix = "/" + s.prefix
+	}
+
+	return nil
+}
+
+func (s *etcd3store) serviceKey(id string) string {
+	return s.prefix + services + "/" + id
+}
+
+func (s *etcd3store) GetService(ctx context.Context, serviceID string) (*types.VirtualService, error) {
+
+	resp, err := s.client.Get(ctx, s.serviceKey(serviceID))
+	if len(resp.Kvs) == 0 {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve service from store: %v", err)
+	}
+	svc := unmarshalService(resp.Kvs[0].Value)
+	return svc, nil
+}
+
+func (s *etcd3store) PutService(ctx context.Context, service *types.VirtualService) error {
+	b, err := proto.Marshal(service)
+	if err != nil {
+		panic(err)
+	}
+
+	if _, err := s.client.Put(ctx, s.serviceKey(service.Id), string(b)); err != nil {
+		return fmt.Errorf("unable to store service %s: %v", service.Id, err)
+	}
+
+	return nil
+}
+
+func (s *etcd3store) DeleteService(ctx context.Context, serviceID string) error {
+	_, err := s.client.Delete(ctx, s.serviceKey(serviceID))
+	return err
+}
+
+func (s *etcd3store) serverDir(serviceID string) string {
+	return s.prefix + servers + "/" + serviceID
+}
+
+func (s *etcd3store) serverKey(serviceID string, key *types.RealServer_Key) string {
+	return fmt.Sprintf("%s/%s:%d", s.serverDir(serviceID), key.Ip, key.Port)
+}
+
+func (s *etcd3store) GetServer(ctx context.Context, serviceID string, key *types.RealServer_Key) (*types.RealServer, error) {
+	if key == nil {
+		// can't retrieve server without a key
+		return nil, nil
+	}
+	resp, err := s.client.Get(ctx, s.serverKey(serviceID, key))
+	if len(resp.Kvs) == 0 {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve server from store: %v", err)
+	}
+	server := unmarshalServer(resp.Kvs[0].Value)
+	return server, nil
+}
+
+func (s *etcd3store) PutServer(ctx context.Context, server *types.RealServer) error {
+	b, err := proto.Marshal(server)
+	if err != nil {
+		panic(err)
+	}
+
+	key := s.serverKey(server.ServiceID, server.Key)
+	if _, err := s.client.Put(ctx, key, string(b)); err != nil {
+		return fmt.Errorf("unable to store server %s: %v", key, err)
+	}
+
+	return nil
+}
+
+func (s *etcd3store) DeleteServer(ctx context.Context, serviceID string, key *types.RealServer_Key) error {
+	serverKey := s.serverKey(serviceID, key)
+	_, err := s.client.Delete(ctx, serverKey)
+	return err
+}
+
+func (s *etcd3store) ListServices(ctx context.Context) ([]*types.VirtualService, error) {
+	resp, err := s.client.Get(ctx, s.serviceKey(""), clientv3.WithPrefix())
+	if err != nil {
+		return nil, fmt.Errorf("unable to list services: %v", err)
+	}
+
+	var services []*types.VirtualService
+	for _, node := range resp.Kvs {
+		service := unmarshalService(node.Value)
+		services = append(services, service)
+	}
+	return services, nil
+}
+
+func (s *etcd3store) ListServers(ctx context.Context, serviceID string) ([]*types.RealServer, error) {
+	resp, err := s.client.Get(ctx, s.serverDir(serviceID), clientv3.WithPrefix())
+	if client.IsKeyNotFound(err) {
+		return []*types.RealServer{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("unable to list servers for %s: %v", serviceID, err)
+	}
+
+	var servers []*types.RealServer
+	for _, node := range resp.Kvs {
+		server := unmarshalServer(node.Value)
+		servers = append(servers, server)
+	}
+	return servers, nil
+}
+
+func (s *etcd3store) Subscribe(subscriber func(), stopCh <-chan struct{}) {
+
+	go func() {
+		ctx, cancelFunc := context.WithCancel(context.Background())
+
+		watcher := s.client.Watch(ctx, s.prefix, clientv3.WithPrefix())
+		respCh := make(chan clientv3.WatchResponse)
+
+		defer cancelFunc()
+		s.handleWatcherUpdates(ctx, watcher, respCh)
+
+		for {
+			select {
+			case <-respCh:
+				subscriber()
+			case <-stopCh:
+				return
+			}
+		}
+	}()
+}
+
+func (s *etcd3store) handleWatcherUpdates(ctx context.Context, watcher clientv3.WatchChan, respCh chan<- clientv3.WatchResponse) {
+	handler := func() error {
+		resp := <-watcher
+		if resp.Err() == nil {
+			respCh <- resp
+		} else {
+			if ctx.Err() != nil {
+				// context was cancelled, exit handler
+				return &backoff.PermanentError{Err: resp.Err()}
+			}
+			log.Warnf("etcd watcher: %v", resp.Err())
+		}
+		return resp.Err()
+	}
+
+	expBackoff := backoff.NewExponentialBackOff()
+	// never stop retrying
+	expBackoff.MaxElapsedTime = 0
+
+	go func() {
+		for {
+			err := backoff.Retry(handler, expBackoff)
+			if err != nil {
+				break
+			}
+		}
+	}()
+}

--- a/store/etcd3_store.go
+++ b/store/etcd3_store.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/cenkalti/backoff"
-	"github.com/coreos/etcd/client"
 	"github.com/coreos/etcd/clientv3"
 	"github.com/golang/protobuf/proto"
 	log "github.com/sirupsen/logrus"
@@ -47,7 +46,6 @@ func (s *etcd3store) serviceKey(id string) string {
 }
 
 func (s *etcd3store) GetService(ctx context.Context, serviceID string) (*types.VirtualService, error) {
-
 	resp, err := s.client.Get(ctx, s.serviceKey(serviceID))
 	if len(resp.Kvs) == 0 {
 		return nil, nil
@@ -137,7 +135,7 @@ func (s *etcd3store) ListServices(ctx context.Context) ([]*types.VirtualService,
 
 func (s *etcd3store) ListServers(ctx context.Context, serviceID string) ([]*types.RealServer, error) {
 	resp, err := s.client.Get(ctx, s.serverDir(serviceID), clientv3.WithPrefix())
-	if client.IsKeyNotFound(err) {
+	if len(resp.Kvs) == 0 {
 		return []*types.RealServer{}, nil
 	}
 	if err != nil {
@@ -153,7 +151,6 @@ func (s *etcd3store) ListServers(ctx context.Context, serviceID string) ([]*type
 }
 
 func (s *etcd3store) Subscribe(subscriber func(), stopCh <-chan struct{}) {
-
 	go func() {
 		ctx, cancelFunc := context.WithCancel(context.Background())
 

--- a/store/store.go
+++ b/store/store.go
@@ -41,7 +41,7 @@ func NewStore(storeBackend string, endpoints []string, prefix string) (Store, er
 	}
 }
 
-func unmarshalString(raw string) []byte {
+func base64decode(raw string) []byte {
 	b, err := base64.StdEncoding.DecodeString(raw)
 	if err != nil {
 		panic(fmt.Errorf("unable to decode - did you break backwards compatibility?: %v", err))

--- a/store/store.go
+++ b/store/store.go
@@ -2,26 +2,16 @@ package store
 
 import (
 	"context"
-	"time"
-
 	"encoding/base64"
 	"fmt"
-	"strings"
 
-	"github.com/cenkalti/backoff"
-	"github.com/coreos/etcd/client"
 	"github.com/golang/protobuf/proto"
-	log "github.com/sirupsen/logrus"
 	"github.com/sky-uk/merlin/types"
 )
 
 const (
 	services = "/services"
 	servers  = "/servers"
-)
-
-var (
-	getOpts = &client.GetOptions{Quorum: true}
 )
 
 // Store for saving desired IPVS state.
@@ -38,252 +28,40 @@ type Store interface {
 	Subscribe(subscriber func(), stopCh <-chan struct{})
 }
 
-type store struct {
-	c      client.Client
-	prefix string
-	kapi   client.KeysAPI
+// NewStore returns a Store implementation based upon the storeBackend parameter
+func NewStore(storeBackend string, endpoints []string, prefix string) (Store, error) {
+
+	switch storeBackend {
+	case "etcd2":
+		return NewEtcd2(endpoints, prefix)
+	case "etcd3":
+		return NewEtcd3(endpoints, prefix)
+	default:
+		return nil, fmt.Errorf("unknown store backend: %s", storeBackend)
+	}
 }
 
-// NewEtcd2 returns a Store implementation using an etcd2 backing store.
-func NewEtcd2(endpoints []string, prefix string) (Store, error) {
-	cfg := client.Config{
-		Endpoints:               endpoints,
-		Transport:               client.DefaultTransport,
-		HeaderTimeoutPerRequest: time.Second,
-	}
-	log.Debug("Creating etcd2 client")
-	c, err := client.New(cfg)
-	if err != nil {
-		return nil, err
-	}
-	s := &store{c: c, prefix: prefix, kapi: client.NewKeysAPI(c)}
-
-	return s, s.init()
-}
-
-func (s *store) init() error {
-	if !strings.HasPrefix(s.prefix, "/") {
-		s.prefix = "/" + s.prefix
-	}
-
-	// initialize prefix directory
-	if err := s.initDir(s.prefix); err != nil {
-		return fmt.Errorf("failed to create %s directory: %v", s.prefix, err)
-	}
-
-	// initialize services directory
-	if err := s.initDir(s.prefix + services); err != nil {
-		return fmt.Errorf("failed to create %s%s directory: %v", s.prefix, services, err)
-	}
-
-	// initialize servers directory
-	if err := s.initDir(s.prefix + servers); err != nil {
-		return fmt.Errorf("failed to create %s%s directory: %v", s.prefix, servers, err)
-	}
-
-	return nil
-}
-
-func (s *store) initDir(dir string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	opts := client.SetOptions{Dir: true}
-
-	_, err := s.kapi.Get(ctx, dir, nil)
-	if !client.IsKeyNotFound(err) {
-		return err
-	}
-
-	if _, err := s.kapi.Set(ctx, dir, "", &opts); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (s *store) serviceKey(id string) string {
-	return s.prefix + services + "/" + id
-}
-
-func unmarshal(pb proto.Message, raw string) proto.Message {
+func unmarshalString(raw string) []byte {
 	b, err := base64.StdEncoding.DecodeString(raw)
 	if err != nil {
 		panic(fmt.Errorf("unable to decode - did you break backwards compatibility?: %v", err))
 	}
+	return b
+}
+
+func unmarshal(pb proto.Message, b []byte) proto.Message {
 	if err := proto.Unmarshal(b, pb); err != nil {
 		panic(fmt.Errorf("unable to unmarshal - did you break backwards compatibility?: %v", err))
 	}
 	return pb
 }
 
-func unmarshalService(raw string) *types.VirtualService {
+func unmarshalService(raw []byte) *types.VirtualService {
 	var service types.VirtualService
 	return unmarshal(&service, raw).(*types.VirtualService)
 }
 
-func (s *store) GetService(ctx context.Context, serviceID string) (*types.VirtualService, error) {
-	resp, err := s.kapi.Get(ctx, s.serviceKey(serviceID), getOpts)
-	if client.IsKeyNotFound(err) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("unable to retrieve service from store: %v", err)
-	}
-	svc := unmarshalService(resp.Node.Value)
-	return svc, nil
-}
-
-func (s *store) PutService(ctx context.Context, service *types.VirtualService) error {
-	b, err := proto.Marshal(service)
-	if err != nil {
-		panic(err)
-	}
-
-	enc := base64.StdEncoding.EncodeToString(b)
-	if _, err := s.kapi.Set(ctx, s.serviceKey(service.Id), enc, nil); err != nil {
-		return fmt.Errorf("unable to store service %s: %v", service.Id, err)
-	}
-
-	return nil
-}
-
-func (s *store) DeleteService(ctx context.Context, serviceID string) error {
-	_, err := s.kapi.Delete(ctx, s.serviceKey(serviceID), nil)
-	return err
-}
-
-func (s *store) serverDir(serviceID string) string {
-	return s.prefix + servers + "/" + serviceID
-}
-
-func (s *store) serverKey(serviceID string, key *types.RealServer_Key) string {
-	return fmt.Sprintf("%s/%s:%d", s.serverDir(serviceID), key.Ip, key.Port)
-}
-
-func unmarshalServer(raw string) *types.RealServer {
+func unmarshalServer(raw []byte) *types.RealServer {
 	var server types.RealServer
 	return unmarshal(&server, raw).(*types.RealServer)
-}
-
-func (s *store) GetServer(ctx context.Context, serviceID string, key *types.RealServer_Key) (*types.RealServer, error) {
-	if key == nil {
-		// can't retrieve server without a key
-		return nil, nil
-	}
-	resp, err := s.kapi.Get(ctx, s.serverKey(serviceID, key), getOpts)
-	if client.IsKeyNotFound(err) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("unable to retrieve server from store: %v", err)
-	}
-	server := unmarshalServer(resp.Node.Value)
-	return server, nil
-}
-
-func (s *store) PutServer(ctx context.Context, server *types.RealServer) error {
-	if err := s.initDir(s.serverDir(server.ServiceID)); err != nil {
-		return fmt.Errorf("unable to init %s/%s: %v", servers, server.ServiceID, err)
-	}
-
-	b, err := proto.Marshal(server)
-	if err != nil {
-		panic(err)
-	}
-
-	enc := base64.StdEncoding.EncodeToString(b)
-	key := s.serverKey(server.ServiceID, server.Key)
-	if _, err := s.kapi.Set(ctx, key, enc, nil); err != nil {
-		return fmt.Errorf("unable to store server %s: %v", key, err)
-	}
-
-	return nil
-}
-
-func (s *store) DeleteServer(ctx context.Context, serviceID string, key *types.RealServer_Key) error {
-	serverKey := s.serverKey(serviceID, key)
-	_, err := s.kapi.Delete(ctx, serverKey, nil)
-	return err
-}
-
-func (s *store) ListServices(ctx context.Context) ([]*types.VirtualService, error) {
-	resp, err := s.kapi.Get(ctx, s.serviceKey(""), getOpts)
-	if err != nil {
-		return nil, fmt.Errorf("unable to list services: %v", err)
-	}
-
-	var services []*types.VirtualService
-	for _, node := range resp.Node.Nodes {
-		service := unmarshalService(node.Value)
-		services = append(services, service)
-	}
-	return services, nil
-}
-
-func (s *store) ListServers(ctx context.Context, serviceID string) ([]*types.RealServer, error) {
-	resp, err := s.kapi.Get(ctx, s.serverDir(serviceID), getOpts)
-	if client.IsKeyNotFound(err) {
-		return []*types.RealServer{}, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("unable to list servers for %s: %v", serviceID, err)
-	}
-
-	var servers []*types.RealServer
-	for _, node := range resp.Node.Nodes {
-		server := unmarshalServer(node.Value)
-		servers = append(servers, server)
-	}
-	return servers, nil
-}
-
-func (s *store) Subscribe(subscriber func(), stopCh <-chan struct{}) {
-	options := &client.WatcherOptions{
-		Recursive: true,
-	}
-	watcher := s.kapi.Watcher(s.prefix, options)
-	respCh := make(chan *client.Response)
-
-	go func() {
-		ctx, cancelFunc := context.WithCancel(context.Background())
-		defer cancelFunc()
-		handleWatcherUpdates(ctx, watcher, respCh)
-
-		for {
-			select {
-			case <-respCh:
-				subscriber()
-			case <-stopCh:
-				return
-			}
-		}
-	}()
-}
-
-func handleWatcherUpdates(ctx context.Context, watcher client.Watcher, respCh chan<- *client.Response) {
-	handler := func() error {
-		resp, err := watcher.Next(ctx)
-		if err == nil {
-			respCh <- resp
-		} else {
-			if ctx.Err() != nil {
-				// context was cancelled, exit handler
-				return &backoff.PermanentError{Err: err}
-			}
-			log.Warnf("etcd watcher: %v", err)
-		}
-		return err
-	}
-
-	expBackoff := backoff.NewExponentialBackOff()
-	// never stop retrying
-	expBackoff.MaxElapsedTime = 0
-
-	go func() {
-		for {
-			err := backoff.Retry(handler, expBackoff)
-			if err != nil {
-				break
-			}
-		}
-	}()
 }


### PR DESCRIPTION
Adds support for etcd3 APIs.
Add `store-backend` switch to allow merlin to be configured to use
the existing etcd2 or the new etcd3 store backend. Defaults to etcd2.