### PR TITLE
Update Alpine image and golang version (#25)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-- 1.9
+- 1.11
 
 services:
 - docker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.2.1
+
+* Update alpine image to fix CVE-2019-5021.
+* Update to go version 1.11
+
 # 0.2.0
 
 * Add support for etcd3 storage backend

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.9
 
 WORKDIR /
 COPY meradm /meradm


### PR DESCRIPTION
* Update Alpine image

Fixes https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-5021

* Update to golang 1.11